### PR TITLE
Test for cmdu fragment duplicates

### DIFF
--- a/src/cmdu_codec.rs
+++ b/src/cmdu_codec.rs
@@ -1231,10 +1231,10 @@ impl CMDU {
             }
         }
 
-        // Verify EndOfMessage flag on the last fragment
+        // Verify LastFragment flag on the last fragment
         let last = fragments.last().unwrap();
         if last.flags & 0x80 == 0 {
-            return Err(CmduReassemblyError::MissingEndOfMessage);
+            return Err(CmduReassemblyError::MissingLastFragment);
         }
 
         // Reassemble payload
@@ -2090,7 +2090,7 @@ pub mod tests {
         let cmdu = make_dummy_cmdu(vec![1500 - 8 - 3 + 1]); // Whole CMDU (with CMDU header) has 1501 bytes
 
         // Try to do the fragmentation on CMDU
-        // It should panic in fragment() as the third TLV (1500B) exceeds maximum allowed size: (MTU - CMDU_header - TLV_header)
+        // It should panic in fragment() as the TLV (1501B) exceeds maximum allowed size: (MTU - CMDU_header - TLV_header)
         let _fragments = cmdu.clone().fragment(1500);
     }
 
@@ -2164,7 +2164,7 @@ pub mod tests {
         let fragments: Vec<CMDU> = vec![cmdu1, cmdu2];
         let reassembled = CMDU::reassemble(fragments).expect_err("Reassembly shouldn't succeed on missed EndOfMessage TLV");
 
-        assert_eq!(reassembled, CmduReassemblyError::MissingEndOfMessage);
+        assert_eq!(reassembled, CmduReassemblyError::MissingLastFragment);
     }
 
     #[test]
@@ -2493,15 +2493,86 @@ pub mod tests {
         let bad_tlv_length = TLV {
             tlv_type: IEEE1905TLVType::VendorSpecificInfo.to_u8(),
             tlv_length: 100,
-            tlv_value: Some(vec![ 1 ])
+            tlv_value: Some(vec![1]),
         };
         let cmdu_serialized = cmdu.serialize();
         let mut cmdu_payload_extended = cmdu_serialized.clone();
         cmdu_payload_extended.append(&mut bad_tlv_length.serialize());
-        let (_, cmdu_parsed )= CMDU::parse(cmdu_payload_extended.as_slice()).unwrap();
+        let (_, cmdu_parsed) = CMDU::parse(cmdu_payload_extended.as_slice()).unwrap();
 
-        // Here we expect panic as the bad_tlv_length.tlv_length doesn't match the TLV length
+        // Expect panic as the bad_tlv_length.tlv_length doesn't match the real TLV length
         let _tlvs = cmdu_parsed.get_tlvs();
+    }
+
+
+    // Test sequence of CMDU fragments that arrived out of order.
+    #[test]
+    #[cfg(feature = "size_based_fragmentation")]
+    fn test_out_of_order_fragments() {
+        let mut cmdu0 = make_dummy_cmdu(vec![10, 20]);
+        let mut cmdu1 = make_dummy_cmdu(vec![30, 40]);
+        let mut cmdu2 = make_dummy_cmdu(vec![50, 60]);
+
+        cmdu0.fragment = 0;
+        cmdu1.fragment = 1;
+        cmdu2.fragment = 2;
+
+        // Set last fragment flag
+        cmdu2.flags = 0x80;
+
+        // Prepare vector with out of order CMDU fragments
+        let fragments: Vec<CMDU> = vec![cmdu0, cmdu2, cmdu1];
+
+        // Pass the vector with out of order CMDUs
+        let reassembled = CMDU::reassemble(fragments);
+        assert!(reassembled.is_ok());
+
+        // Verify the length of reassembled CMDU payload which is sum of 6 TLV headers and their payload
+        // 6 TLVs data take 210 bytes and additional 6 TLV headers takes 3 bytes each
+        #[cfg(feature = "size_based_fragmentation")]
+        assert_eq!(reassembled.clone().unwrap().payload.len(), 10 + 20 + 30 + 40 + 50 + 60 + 6 * 3);
+
+        // Verify if the data from out of order CMDUs are in proper order after reassembly.
+        let mut offset = 0;
+
+        // Define vector of sizes of consecutive TLVs for verification (from already sorted CMDUs)
+        let sizes = vec![10, 20, 30, 40, 50, 60];
+
+        // Iter on all the TLVs and check their size with the predefined vector "sizes"
+        for i in sizes.iter() {
+            let chunk = &reassembled.clone().unwrap().payload[offset..offset + 3 + i];
+
+            #[cfg(feature = "size_based_fragmentation")]
+            assert_eq!(TLV::parse(chunk).unwrap().1.tlv_length, *i as u16);
+
+            // Move offset to the next chunk: size of current TLV payload + TLV header length
+            offset += i + 3;
+        }
+    }
+
+    // Test if CMDU reassembly procedure reports missed CMDU fragment
+    #[test]
+    fn test_missed_one_fragment() {
+        let mut cmdu0 = make_dummy_cmdu(vec![10, 20]);
+        let mut cmdu1 = make_dummy_cmdu(vec![30, 40]);
+        let mut cmdu2 = make_dummy_cmdu(vec![50, 60]);
+        let mut cmdu3 = make_dummy_cmdu(vec![70, 80]);
+
+        // Create CMDU fragments chain with missing fragment No. 2
+        cmdu0.fragment = 0;
+        cmdu1.fragment = 1;
+        cmdu2.fragment = 3;         // Skip fragment 2 and set fragment to id = 3
+        cmdu3.fragment = 4;
+
+        // Set last fragment flag
+        cmdu3.flags = 0x80;
+
+        // Prepare vector with CMDU fragments
+        let fragments: Vec<CMDU> = vec![cmdu0, cmdu1, cmdu2, cmdu3];
+        let reassembled = CMDU::reassemble(fragments);
+
+        // Expect MissingFragments error
+        assert_eq!(CmduReassemblyError::MissingFragments, reassembled.unwrap_err());
     }
 }
 //TODO move everything to size based fragementation and verify all the unit test

--- a/src/cmdu_handler.rs
+++ b/src/cmdu_handler.rs
@@ -1009,6 +1009,7 @@ mod tests {
     use crate::interface_manager::get_forwarding_interface_name;
     use crate::interface_manager::get_local_al_mac;
     use tokio::sync::Mutex;
+    use crate::cmdu_reassembler::CmduReassemblyError;
 
     #[tokio::test]
     #[should_panic]
@@ -1238,5 +1239,36 @@ mod tests {
             }
         }
         assert!(reassembled.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_recognition_of_duplicate_fragment() {
+        let mut cmdu0 = make_dummy_cmdu(vec![10, 20]);
+        let mut cmdu1 = make_dummy_cmdu(vec![30, 40]);
+        let mut cmdu2 = make_dummy_cmdu(vec![50, 60]);
+
+        cmdu0.fragment = 0;
+        cmdu1.fragment = 1;
+        cmdu2.fragment = 1;         // duplicated fragment No. 1
+        cmdu2.flags = 0x80;         // set last fragment flag
+
+        let source_mac = MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66);
+        let fragments = vec![cmdu0, cmdu1, cmdu2];
+        let cmdu_reasm = CmduReassembler::new().await;
+
+        for fragment in fragments.iter() {
+            match cmdu_reasm.push_fragment(source_mac, fragment.clone()).await {
+                Some(Ok(_)) => {
+                    panic!("DuplicatedFragment error expected but CMDU is completely reassembled");
+                }
+                Some(Err(e)) => {
+                    assert_eq!(e, CmduReassemblyError::DuplicatedFragment);
+                    error!("Error reassembling CMDU: {:?}", e);
+                }
+                None => {
+                    trace!("Fragment stored. Waiting for more...");
+                }
+            }
+        }
     }
 }

--- a/src/cmdu_reassembler.rs
+++ b/src/cmdu_reassembler.rs
@@ -105,7 +105,11 @@ impl CmduReassembler {
             first_received: Instant::now(),
         });
 
-        entry.fragments.insert(fragment.fragment, fragment.clone());
+        let inserted = entry.fragments.insert(fragment.fragment, fragment.clone());
+        if inserted.is_some() {
+            tracing::trace!("Duplicated fragment: {:?}", fragment.fragment);
+            return Some(Err(CmduReassemblyError::DuplicatedFragment));
+        }
 
         if fragment.is_last_fragment() {
             tracing::trace!("All fragments arrived. Generating reassembled CMDU");

--- a/src/cmdu_reassembler.rs
+++ b/src/cmdu_reassembler.rs
@@ -31,14 +31,18 @@ use std::time::Instant;
 // Internal modules
 use crate::cmdu::CMDU;
 use crate::task_registry::TASK_REGISTRY;
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum CmduReassemblyError {
     EmptyFragments,
     InconsistentMetadata,
-    MissingFragments,
-    MissingEndOfMessage,
+    MissingFragments,                   // Missing CMDU fragment in CMDU chain
+    MissingLastFragment,                // Missing last CMDU fragment with CMDU.flags == 0x80
+    WaitingForMoreFragments,
+    MessageComplete,                    // The whole CMDU is completed
+    DuplicatedFragment                  // Duplicated value of fragment.fragment noticed
 }
-#[derive(Debug)]
+
+#[derive(Debug, Clone)]
 struct FragmentBuffer {
     fragments: BTreeMap<u8, CMDU>,
     first_received: Instant,
@@ -70,7 +74,7 @@ impl CmduReassembler {
                         if entry.fragments.is_empty() {
                             tracing::error!("Reassembly error for {:?}: EmptyFragments", key);
                         } else if !entry.fragments.values().any(|f| f.is_last_fragment()) {
-                            tracing::error!("Reassembly error for {:?}: MissingEndOfMessage", key);
+                            tracing::error!("Reassembly error for {:?}: MissingLastFragment", key);
                         } else {
                             let last_id = entry.fragments.keys().max().cloned().unwrap_or(0);
                             if entry.fragments.len() < (last_id + 1) as usize {
@@ -113,6 +117,161 @@ impl CmduReassembler {
             None
         }
     }
+}
 
+
+#[cfg(test)]
+pub mod tests {
+    use tracing::{error, trace};
+    use crate::cmdu::TLV;
+    use crate::cmdu_codec::tests::make_dummy_cmdu;
+    use tokio::time::sleep;
+    use super::*;
+
+    // Create CMDU reassembler instance but don't push any fragments to it
+    #[tokio::test]
+    async fn test_empty_fragment() {
+        let cmdu_reasm = CmduReassembler::new().await;
+
+        // Wait longer than 3 seconds timeout set in tokio async in new() method
+        sleep(Duration::from_secs(4)).await;
+
+        // Check if CMDU reassembler instance still exists after 4 seconds and is empty
+        assert!(cmdu_reasm.buffer.lock().await.is_empty());
+    }
+
+    // Simulate lost of fragment 2 to verify missing fragment with last flag set.
+    #[tokio::test]
+    async fn test_simulate_lost_of_fragment_2() {
+        // Create simple TLV
+        let tlv = TLV {
+            tlv_type: 0x01,
+            tlv_length: 0,
+            tlv_value: None,
+        };
+
+        // Create only one CMDU
+        let cmdu = CMDU {
+            message_version: 0,
+            reserved: 0,
+            message_type: 0x04,
+            message_id: 0x1122,
+            fragment: 0,
+            flags: 0x00,     // last fragment flag is not set intentionally as this is not last fragment
+            #[cfg(feature = "size_based_fragmentation")]
+            payload: tlv.serialize(),
+            #[cfg(not(feature = "size_based_fragmentation"))]
+            payload: vec![tlv],
+        };
+
+        let cmdu_reasm = CmduReassembler::new().await;
+
+        // Push the only fragment
+        let _ = cmdu_reasm.push_fragment(MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66), cmdu.clone()).await;
+
+        // Expect one fragment in CMDU reassembler buffer before 3 seconds timeout elapsed
+        assert!(!cmdu_reasm.buffer.lock().await.is_empty());
+
+        // Wait longer than 3 seconds of timeout in async in new()
+        sleep(Duration::from_secs(4)).await;
+
+        // Expect empty CMDU reassembler buffer after 3 seconds timeout elapsed
+        // as async function in new() should remove the only existing fragment
+        // because of simulating lost of last fragment (should have bit 7 set in CMDU flags)
+        assert!(cmdu_reasm.buffer.lock().await.is_empty());
+    }
+
+    // Verify removing bad CMDU chain after 3 seconds of timeout
+    #[tokio::test]
+    async fn test_inserting_two_fragments_without_last_fragment_flag() {
+        // Create 2 TLVs
+        let tlv1 = TLV {
+            tlv_type: 0x01,
+            tlv_length: 0,
+            tlv_value: None,
+        };
+        let tlv2 = TLV {
+            tlv_type: 0x02,
+            tlv_length: 0,
+            tlv_value: None,
+        };
+
+        // Create chain of 2 CMDUs. Both CMDUs have no last fragment flag set to simulate
+        // lost of fragment 3
+        let cmdu1 = CMDU {
+            message_version: 0,
+            reserved: 0,
+            message_type: 0x04,
+            message_id: 0x1122,
+            fragment: 0,
+            flags: 0x00,
+            #[cfg(feature = "size_based_fragmentation")]
+            payload: tlv1.serialize(),
+            #[cfg(not(feature = "size_based_fragmentation"))]
+            payload: vec![tlv1],
+        };
+
+        let cmdu2 = CMDU {
+            message_version: 0,
+            reserved: 0,
+            message_type: 0x04,
+            message_id: 0x1122,
+            fragment: 1,
+            flags: 0x00,
+            #[cfg(feature = "size_based_fragmentation")]
+            payload: tlv2.serialize(),
+            #[cfg(not(feature = "size_based_fragmentation"))]
+            payload: vec![tlv2],
+        };
+
+        let cmdu_reasm = CmduReassembler::new().await;
+
+        // Add both CMDUs to CMDU reassembler buffer
+        let _ = cmdu_reasm.push_fragment(MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66), cmdu1.clone()).await;
+        let _ = cmdu_reasm.push_fragment(MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66), cmdu2.clone()).await;
+
+        // Verify that there is one entry in HashMap for MAC: 11:22:33:44:55:66 and message_id 0x1122
+        assert_eq!(cmdu_reasm.buffer.lock().await.len(), 1);
+        // Verify that there are 2 entries in BTreeMap (2 CMDU fragments)
+        assert_eq!(cmdu_reasm.buffer.lock().await.get(&(MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66), 0x1122)).unwrap().fragments.len(), 2);
+
+        // Wait longer that 3 seconds of timeout of async from new()
+        sleep(Duration::from_secs(4)).await;
+
+        // After timeout in async from new() there should not be any entry in HashMap
+        assert!(cmdu_reasm.buffer.lock().await.is_empty());
+    }
+
+    // Check recognition of missed fragment in the middle of CMDU chain
+    #[tokio::test]
+    async fn test_reassembler_missing_fragment() {
+        let mut cmdu0 = make_dummy_cmdu(vec![10, 20]);
+        let mut cmdu1 = make_dummy_cmdu(vec![30, 40]);
+        let mut cmdu2 = make_dummy_cmdu(vec![50, 60]);
+
+        cmdu0.fragment = 0;
+        cmdu1.fragment = 2;         // skip fragment id == 1 to signal missed fragment 1
+        cmdu2.fragment = 3;
+        cmdu2.flags = 0x80;         // set last fragment flag
+
+        let source_mac = MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66);
+        let fragments = vec![cmdu0, cmdu1, cmdu2];
+        let cmdu_reasm = CmduReassembler::new().await;
+
+        for fragment in fragments.iter() {
+            match cmdu_reasm.push_fragment(source_mac, fragment.clone()).await {
+                Some(Ok(_)) => {
+                    panic!("MissedFragment error expected but CMDU is completely reassembled");
+                }
+                Some(Err(e)) => {
+                    assert_eq!(e, CmduReassemblyError::MissingFragments);
+                    error!("Error reassembling CMDU: {:?}", e);
+                }
+                None => {
+                    trace!("Fragment stored. Waiting for more...");
+                }
+            }
+        }
+    }
 }
 //TODO unit test for reassembler and check use cases for out of order fragments, missing fragments, and empty fragments


### PR DESCRIPTION
Recognize and report CMDU fragment duplicates
    
Currently CMDU reassembler doesn't recognize duplicated CMDU fragments while reassembling.
Add detection and reporting of this particular case.
Add unit test to cover this specific case.
