### PR TITLE
[#23] Documentation of unit tests

### DIFF
--- a/src/cmdu_reassembler.rs
+++ b/src/cmdu_reassembler.rs
@@ -162,10 +162,7 @@ pub mod tests {
             message_id: 0x1122,
             fragment: 0,
             flags: 0x00,     // last fragment flag is not set intentionally as this is not last fragment
-            #[cfg(feature = "size_based_fragmentation")]
             payload: tlv.serialize(),
-            #[cfg(not(feature = "size_based_fragmentation"))]
-            payload: vec![tlv],
         };
 
         let cmdu_reasm = CmduReassembler::new().await;
@@ -209,10 +206,7 @@ pub mod tests {
             message_id: 0x1122,
             fragment: 0,
             flags: 0x00,
-            #[cfg(feature = "size_based_fragmentation")]
             payload: tlv1.serialize(),
-            #[cfg(not(feature = "size_based_fragmentation"))]
-            payload: vec![tlv1],
         };
 
         let cmdu2 = CMDU {
@@ -222,10 +216,7 @@ pub mod tests {
             message_id: 0x1122,
             fragment: 1,
             flags: 0x00,
-            #[cfg(feature = "size_based_fragmentation")]
             payload: tlv2.serialize(),
-            #[cfg(not(feature = "size_based_fragmentation"))]
-            payload: vec![tlv2],
         };
 
         let cmdu_reasm = CmduReassembler::new().await;

--- a/src/lldpdu_codec.rs
+++ b/src/lldpdu_codec.rs
@@ -269,6 +269,7 @@ mod tests {
     use crate::lldpdu_codec::LLDPTLVType;
     use crate::tlv_lldpdu_codec::TLV;
 
+    // Verify the correctness of serialization and parsing
     #[test]
     fn test_lldpdu_serialization_and_parsing() {
         let chassis_id = TLV {
@@ -327,6 +328,7 @@ mod tests {
         assert_eq!(parsed_lldpdu.payload[4], end_of_lldpdu);
     }
 
+    // Verify serialization and parsing of organizationally specific (unknown) TLV
     #[test]
     fn test_lldpdu_with_unknown_tlv() {
         let unknown_tlv = TLV {
@@ -353,6 +355,7 @@ mod tests {
         assert_eq!(parsed.payload[1], end_of_lldpdu);
     }
 
+    // Verify Chassis ID serialization and parsing
     #[test]
     fn test_chassis_id_serialization_and_parsing() {
         let chassis_id_original = ChassisId {
@@ -371,6 +374,7 @@ mod tests {
         assert!(error_parse.is_err());
     }
 
+    // Verify Port ID serialization and parsing
     #[test]
     fn test_port_id_serialization_and_parsing() {
         let port_id_original = PortId {
@@ -389,6 +393,7 @@ mod tests {
         assert!(error_parse.is_err());
     }
 
+    // Verify TTL serialization and parsing
     #[test]
     fn test_time_to_live_serialization_and_parsing() {
         let time_to_live_original = TimeToLiveTLV {
@@ -405,5 +410,4 @@ mod tests {
         let parse_error = TimeToLiveTLV::parse(&time_to_live_bytes, 3);
         assert!(parse_error.is_err());
     }
-
 }

--- a/src/registration_codec.rs
+++ b/src/registration_codec.rs
@@ -209,82 +209,59 @@ impl AlTopologyChange {
 pub mod tests {
     use super::*;
 
-    // Test registration request parser for too short registration request data packet.
-    // Registration request should contain exactly 2 bytes. Try to parse only 1 byte request
-    // to check if parser returns error: LengthValue. It should.
+    // Verify recognition and signalling of too short registration request
     #[test]
+    #[should_panic]
     fn test_parse_too_short_registration_request() {
-        // Pass only 1 byte to parser
-        let s = AlServiceRegistrationRequest::parse(&[1]);
-
-        // Expect ErrorKind::LengthValue
-        match s {
-            Err(NomErr::Failure(nom::error::Error { code, .. })) => {
-                assert_eq!(code, ErrorKind::LengthValue);
-            }
-            _ => {
-                panic!("Expected error: LengthValue, but got: {s:?}");
-            }
-        }
+        // Expect panic trying to parse one byte request as registration request needs 2 bytes
+        assert!(AlServiceRegistrationRequest::parse(&[1]).is_ok());
     }
 
-    // Test registration request parser for several proper registration requests.
-    // All tests are expected to pass.
+    // Verify parsing valid registration request
     #[test]
     fn test_parse_proper_registration_request() {
-        // Pass 2 bytes to parser:
-        // byte 0 == 1: ServiceOperation::Enable
-        // byte 1 == 1: ServiceType::EasyMeshAgent
+        // Expect successes parsing valid registration request
         assert!(AlServiceRegistrationRequest::parse(&[1, 1]).is_ok());
         assert_eq!(AlServiceRegistrationRequest::parse(&[1, 1]).unwrap().1.service_operation, ServiceOperation::Enable);
         assert_eq!(AlServiceRegistrationRequest::parse(&[1, 1]).unwrap().1.service_type, ServiceType::EasyMeshAgent);
     }
 
-    // Test service operation parser for proper value. Should succeed.
+    // Verify the correctness of parsing valid ServiceOperation codes
     #[test]
     fn test_parse_proper_service_operation() {
-        // Pass proper value of ServiceOperation::Disable == 2. Expect success in parsing it.
+        // Expect successes parsing valid data
+        assert!(ServiceOperation::parse(&[1]).is_ok());
         assert!(ServiceOperation::parse(&[2]).is_ok());
     }
 
-    // Test service operation parser for improper value.
+    // Verify recognition and signalling trying to parse invalid ServiceOperation code
     #[test]
+    #[should_panic]
     fn test_try_to_parse_inappropriate_service_operation() {
-        // Pass improper value of 0. Expect parse error: ErrorKind::Tag
-        match ServiceOperation::parse(&[0]) {
-            Err(NomErr::Failure(nom::error::Error { code, .. })) => {
-                assert_eq!(code, ErrorKind::Tag);
-            }
-            s => {
-                panic!("Expected error: Tag, but got: {s:?}");
-            }
-        }
+        // Expect panic trying to parse invalid data
+        assert!(ServiceOperation::parse(&[0]).is_ok());
     }
 
-    // Test service type parser for proper value.
+    // Verify the correctness of parsing valid ServiceType codes
     #[test]
     fn test_parse_proper_service_type() {
-        // Pass proper value of ServiceType::EasyMeshController == 2. Expect success.
+        // Expect successes
+        assert!(ServiceType::parse(&[1]).is_ok());
         assert!(ServiceType::parse(&[2]).is_ok());
     }
 
-    // Test service type parser for improper value.
+    // Verify recognition and signalling trying to parse invalid ServiceType code
     #[test]
+    #[should_panic]
     fn test_try_to_parse_inappropriate_service_type() {
-        // Pass wrong value of 0. Expect parse error: ErrorKind::Tag
-        match ServiceType::parse(&[0]) {
-            Err(NomErr::Failure(nom::error::Error { code, .. })) => {
-                assert_eq!(code, ErrorKind::Tag);
-            }
-            s => {
-                panic!("Expected error: Tag, but got: {s:?}");
-            }
-        }
+        // Expect panic trying to parse invalid data as 0 is not valid ServiceType code
+        assert!(ServiceType::parse(&[0]).is_ok());
     }
 
-    // Test parsing of several proper registration results
+    // Verify parsing valid RegistrationResult
     #[test]
     fn test_parse_proper_registration_result() {
+        // Expect successes parsing valid registration result
         assert!(RegistrationResult::parse(&[0]).is_ok());
         assert!(RegistrationResult::parse(&[1]).is_ok());
         assert!(RegistrationResult::parse(&[2]).is_ok());
@@ -306,83 +283,135 @@ pub mod tests {
         }
     }
 
-    // Check if parser returns not consumed data untouched (not modified)
+    // Verify the correctness of parsing and returning not parsed data of RegistrationResult
     #[test]
     fn test_check_consumption_of_registration_result_parser() {
-        // Check if size of returned not used data is correct
+        // Expect none of returned data because of parsing single valid value of 4
         assert_eq!(RegistrationResult::parse(&[4]).unwrap().0.len(), 0);
+
+        // Expect '5' of returned data because of parsing valid value 4 and additional ignored value of 5
         assert_eq!(RegistrationResult::parse(&[4, 5]).unwrap().0.len(), 1);
+        assert_eq!(RegistrationResult::parse(&[4, 5]).unwrap().0, &[5]);
+
         // Check if not consumed part is properly returned, untouched and unparsed by parser at all
+        // Expect returning slice of &[5, 6, 7] values because of parsing: &[4, 5, 6, 7]
         assert_eq!(RegistrationResult::parse(&[4, 5, 6, 7]).unwrap().0, &[5, 6, 7]);
     }
 
-    // Check if parser returns not consumed data untouched (not modified)
+    // Verify the correctness of parsing and returning not parsed data of AlServiceRegistrationRequest
     #[test]
     fn test_check_consumption_of_registration_request_parser() {
-        // Check if size of returned not used data is correct
+        // Expect none of returned data because of parsing valid values: &[1, 2]
         assert_eq!(AlServiceRegistrationRequest::parse(&[1, 2]).unwrap().0.len(), 0);
+
+        // Expect '3' of returned data because of parsing valid: &[1, 2] and ignored value of 3
         assert_eq!(AlServiceRegistrationRequest::parse(&[1, 2, 3]).unwrap().0.len(), 1);
+        assert_eq!(AlServiceRegistrationRequest::parse(&[1, 2, 3]).unwrap().0, &[3]);
+
         // Check if not consumed part is properly returned, untouched and unparsed by parser at all
+        // Expect success returning slice of &[3, 4, 5] values because of parsing: &[1, 2, 3, 4, 5]
         assert_eq!(AlServiceRegistrationRequest::parse(&[1, 2, 3, 4, 5]).unwrap().0, &[3, 4, 5]);
     }
 
+    // Verify serializing and parsing of AlServiceRegistrationResponse
     #[test]
     fn test_registration_response_parse_and_serialize() {
-        let mac_address: Vec<u8> = vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
-        let mut registration_response_data: Vec<u8> = mac_address;
+        // Make MAC address from example data
+        let mac: Vec<u8> = vec![0x02, 0x42, 0xc0, 0xa8, 0x64, 0x02];
+
+        // Prepare vector for AlServiceRegistrationResponse contents
+        let mut registration_response_data: Vec<u8> = mac;
+
+        // Prepare starting message_id value
         let start: Vec<u8> = vec![0x00, 0x01];
+
+        // Prepare ending message_id value
         let end: Vec<u8> = vec![0x00, 0x10];
+
+        // Prepare Success as RegistrationResult
         let result = RegistrationResult::Success.serialize();
 
+        // Combine all parts of AlServiceRegistrationResponse together
         registration_response_data.append(&mut start.clone());
         registration_response_data.append(&mut end.clone());
         registration_response_data.push(result);
 
+        // Do the parsing of AlServiceRegistrationResponse
         let parsed = AlServiceRegistrationResponse::parse(&registration_response_data[..]).unwrap().1;
 
+        // Expect success comparing serialized and then parsed data with original ones
         assert_eq!(parsed.serialize(), registration_response_data);
     }
 
+    // Verify serializing and parsing of AlServiceRegistrationRequest
     #[test]
     fn test_registration_request_parse_and_serialize() {
+        // Prepare Enable as ServiceOperation
         let service_operation = ServiceOperation::Enable.serialize();
+
+        // Prepare EasyMeshAgent as ServiceType
         let service_type = ServiceType::EasyMeshAgent.serialize();
 
+        // Prepare AlServiceRegistrationRequest contents
         let registration_request: Vec<u8> = vec![service_operation, service_type];
+
+        // Do the parsing of AlServiceRegistrationRequest
         let parsed = AlServiceRegistrationRequest::parse(&registration_request[..]).unwrap().1;
 
+        // Expect success comparing serialized and then parsed data with original ones
         assert_eq!(parsed.serialize(), registration_request);
     }
 
+    // Verify parsing and serializing of Add type of AlTopologyChange
     #[test]
-    fn test_topology_parsing_and_serializing_correctness() {
-        let mac_address: Vec<u8> = vec![0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+    fn test_topology_change_parse_and_serialize_add() {
+        // Prepare MAC address from example data
+        let mac: Vec<u8> = vec![0x02, 0x42, 0xc0, 0xa8, 0x64, 0x02];
 
-        // Verify "Add" topology change type
+        // Prepare Add as TopologyChangeType
         let topology_type = TopologyChangeType::Add.serialize();
-        let mut topology_change_data: Vec<u8> = mac_address.clone();
 
+        // Prepare the whole AlTopologyChange contents
+        let mut topology_change_data: Vec<u8> = mac;
         topology_change_data.push(topology_type);
 
+        // Do the parsing of AlTopologyChange
         let parsed = AlTopologyChange::parse(&topology_change_data).unwrap().1;
 
-        assert_eq!(topology_change_data, parsed.serialize());
-
-        // Verify "Delete" topology change type
-        let topology_type = TopologyChangeType::Delete.serialize();
-        let mut topology_change_data: Vec<u8> = mac_address;
-
-        topology_change_data.push(topology_type);
-
-        let parsed = AlTopologyChange::parse(&topology_change_data).unwrap().1;
-
+        // Expect success comparing serialized and then parsed data with original ones
         assert_eq!(topology_change_data, parsed.serialize());
     }
 
+    // Verify parsing and serializing of Delete type of AlTopologyChange
+    #[test]
+    fn test_topology_change_parse_and_serialize_delete() {
+        // Prepare MAC address from example data
+        let mac: Vec<u8> = vec![0x02, 0x42, 0xc0, 0xa8, 0x64, 0x02];
+
+        // Prepare Delete as TopologyChangeType
+        let topology_type = TopologyChangeType::Delete.serialize();
+
+        // Prepare the whole AlTopologyChange contents
+        let mut topology_change_data: Vec<u8> = mac;
+        topology_change_data.push(topology_type);
+
+        // Do the parsing of AlTopologyChange
+        let parsed = AlTopologyChange::parse(&topology_change_data).unwrap().1;
+
+        // Expect success comparing serialized and then parsed data with original ones
+        assert_eq!(topology_change_data, parsed.serialize());
+    }
+
+    // Verify trying to parse invalid TopologyChangeType code
     #[test]
     fn test_topology_change_type_parse_invalid() {
+        // Prepare invalid code 5 of TopologyChangeType
         let bind: Vec<u8> = vec![5];
+
+        // Try to parse invalid value of 5
         let topology_type = TopologyChangeType::parse(&bind);
+
+        // Expect error trying to parse invalid value of 5
         assert!(topology_type.is_err());
     }
 }

--- a/src/tlv_lldpdu_codec.rs
+++ b/src/tlv_lldpdu_codec.rs
@@ -110,6 +110,7 @@ impl TLV {
 mod tests {
     use super::TLV;
 
+    // Verify the correctness of parsing valid data from a slice
     #[test]
     fn test_parse_with_value() {
         let input = &[0x02, 0x07, b'A', b'B', b'C', b'D', b'E', b'F', b'G'];
@@ -130,13 +131,35 @@ mod tests {
         );
     }
 
+    // Try to parse TLV with invalid tlv_length value bigger than the real size of provided data
     #[test]
-    fn test_parse_invalid_tlv_len() {
+    fn test_parse_invalid_tlv_len_bigger_than_real_one() {
+        // tlv_type = 0x01:  tlv_type is made of 7 most significant bits of value from input[0] == 0x02
+        // tlv_length = 0x09 while there are only 7 bytes of payload
         let input = &[0x02, 0x09, b'A', b'B', b'C', b'D', b'E', b'F', b'G'];
         let result = TLV::parse(input);
+
+        // Expect error as a result of parsing because not enough data passed in payload
         assert!(result.is_err());
     }
 
+    // Try to parse TLV with invalid tlv_length value smaller than the real size of provided data
+    #[test]
+    fn test_parse_invalid_tlv_len_smaller_than_real_one() {
+        // tlv_type = 0x01:  tlv_type is made of 7 most significant bits of value from input[0] == 0x02
+        // tlv_length = 0x06 while there are 8 bytes of payload
+        let input = &[0x02, 0x06, b'A', b'B', b'C', b'D', b'E', b'F', b'G', b'H'];
+        let result = TLV::parse(input);
+        println!("Parse result: {:?}", result);
+
+        // Expect success as a result of parsing as parser tooks only the number of bytes stored in tlv_length and returns the rest
+        assert!(result.is_ok());
+
+        // Expect that parser returns redundant (not needed) data: &['G', 'H']
+        assert_eq!(result.unwrap().0, &[b'G', b'H']);
+    }
+
+    // Verify serialization of TLV with valid payload
     #[test]
     fn test_serialize_with_value() {
         let tlv = TLV {
@@ -145,11 +168,15 @@ mod tests {
             tlv_value: Some(vec![0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]),
         };
         let serialized = tlv.serialize();
+
+        // Expect success in serialization process
         assert_eq!(
             serialized,
             vec![0x02, 0x07, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47]
         );
     }
+
+    // Verify serialization of TLV without any payload
     #[test]
     fn test_serialize_without_value() {
         let tlv = TLV {
@@ -158,7 +185,8 @@ mod tests {
             tlv_value: None,
         };
         let serialized = tlv.serialize();
+
+        // Expect success in serialization process
         assert_eq!(serialized, vec![0x02, 0x00]);
     }
 }
-//TODO add a unit test for the case where the length is smaller than the real data and the other way around


### PR DESCRIPTION
Add general and internals description for every unit test.

This patchset is already rebased on #29 so it should be applied after #29.