### PR TITLE
[#41] replace panics with actual error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,16 +510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "eyre"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
-dependencies = [
- "indenter",
- "once_cell",
-]
-
-[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,7 +811,6 @@ dependencies = [
  "console-subscriber",
  "crossterm 0.29.0",
  "cryptoki",
- "eyre",
  "futures",
  "hex-literal",
  "lazy_static",
@@ -838,12 +827,6 @@ dependencies = [
  "tracing-subscriber",
  "tui",
 ]
-
-[[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ crossterm = "0.29.0"
 netdev = "0.37.3"
 anyhow = "1.0.99"
 futures = "0.3"
-eyre = "0.6.12"
 tokio-tasker = "1.2.0"
 tokio-util = "0.7.16"
 clap = { version = "4.5.47", features = ["derive"] }

--- a/examples/functional_tests_receiver.rs
+++ b/examples/functional_tests_receiver.rs
@@ -17,7 +17,6 @@
  * limitations under the License.
 */
 use std::process::exit;
-use eyre::Result;
 use futures::{SinkExt, StreamExt};
 use tokio::net::UnixStream;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
@@ -86,7 +85,7 @@ async fn send_echoed_packet(socket: &mut Framed<&mut UnixStream, LengthDelimited
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> anyhow::Result<()> {
     // Modify this filter for your tracing during run time
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace")); //add 'tokio=trace' to debug the runtime
 

--- a/examples/functional_tests_transmitter.rs
+++ b/examples/functional_tests_transmitter.rs
@@ -18,7 +18,6 @@
 */
 
 use bytes::Bytes;
-use eyre::Result;
 use futures::{SinkExt, StreamExt};
 use ieee1905::cmdu_codec::*;
 use ieee1905::registration_codec::{
@@ -424,7 +423,7 @@ fn prepare_payload_with_huge_tlv(r: &AlServiceRegistrationResponse, multicast: b
 }
 
 
-async fn test1() -> Result<()> {
+async fn test1() -> anyhow::Result<()> {
     // Modify this filter for your tracing during run time
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("trace")); //add 'tokio=trace' to debug the runtime
 
@@ -638,7 +637,7 @@ async fn send_huge_data(
     Ok(sdu_autoconfig_search)
 }
 
-async fn read_data(framed_data_socket: &mut Framed<UnixStream, LengthDelimitedCodec>) -> Result<SDU> {
+async fn read_data(framed_data_socket: &mut Framed<UnixStream, LengthDelimitedCodec>) -> anyhow::Result<SDU> {
     println!("Waiting for any data");
 
     let mut assembled_payload = Vec::new();
@@ -717,7 +716,7 @@ async fn read_data(framed_data_socket: &mut Framed<UnixStream, LengthDelimitedCo
 }
 
 // Read complete SDU with CMDU and TLVs and compare CMDU payload
-async fn read_and_compare_data(framed_data_socket: &mut Framed<UnixStream, LengthDelimitedCodec>, data_to_compare: &Vec<u8>) -> Result<()> {
+async fn read_and_compare_data(framed_data_socket: &mut Framed<UnixStream, LengthDelimitedCodec>, data_to_compare: &Vec<u8>) -> anyhow::Result<()> {
     let sdu_wrapped = read_data(framed_data_socket).await;
     match sdu_wrapped {
         Ok(sdu) => {
@@ -1192,7 +1191,7 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let connect = args.connect.clone();
     let test = args.test_num.clone();

--- a/src/cmdu_codec.rs
+++ b/src/cmdu_codec.rs
@@ -916,7 +916,7 @@ impl CMDU {
         let mut remaining_input = self.payload.as_slice();
         let mut has_reached_end = false;
         while !remaining_input.is_empty() && !has_reached_end {
-                match TLV::parse(remaining_input) {
+            match TLV::parse(remaining_input) {
                 Ok(tlv) => {
                     tracing::trace!("Parsed TLV {:?}", tlv.1);
                     // The minimum Ethernet frame length (over the wire) is 60 bytes
@@ -940,7 +940,8 @@ impl CMDU {
                         .collect::<Vec<String>>()
                         .join(" ");
                     tracing::trace!("Remaining {}", hex_string);
-                    panic!("Failed to parse TLV: {e:?}. Unparseable data: <{hex_string:?}>");
+                    
+                    break // TODO should we allow partially parsed TLV's?
                 }
             }
         }
@@ -1078,8 +1079,7 @@ impl CMDU {
         }
 
         // Verify LastFragment flag on the last fragment
-        let last = fragments.last().unwrap();
-        if last.flags & 0x80 == 0 {
+        if fragments.last().is_none_or(|e| e.flags & 0x80 == 0) {
             return Err(CmduReassemblyError::MissingLastFragment);
         }
 

--- a/src/cmdu_handler.rs
+++ b/src/cmdu_handler.rs
@@ -268,19 +268,21 @@ impl CMDUHandler {
     /// Handles a parsed CMDU, logs details, and extracts TLVs.
     async fn dispatch_cmdu(&self, cmdu: CMDU, source_mac: MacAddr, destination_mac: MacAddr) {
         tracing::trace!("Dispatch CMDU {cmdu:?}");
-        match MessageVersion::from_u8(cmdu.message_version).unwrap() {
-            MessageVersion::Version2013 => {
+        match MessageVersion::from_u8(cmdu.message_version) {
+            Some(MessageVersion::Version2013) => {
                 tracing::trace!("Handling message version 2013");
                 //process_cmdus
                 self.process_cmdus(cmdu, source_mac, destination_mac)
                     .await;
             }
-            _ => {
+            Some(_) => {
                 tracing::trace!("Handling message version different than 2013");
                 //process_sdus
                 self.process_sdus(cmdu, source_mac, destination_mac)
                     .await;
             }
+            // TODO should we handle unknown versions?
+            _ => trace!("Unknown message version: {:02x}", cmdu.message_version),
         }
     }
 

--- a/src/cmdu_message_id_generator.rs
+++ b/src/cmdu_message_id_generator.rs
@@ -18,13 +18,14 @@
 */
 
 #![deny(warnings)]
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, Ordering};
 use tokio::sync::OnceCell;
 use tracing::{debug, info}; // Import tracing
 
 /// A global Message ID generator.
 pub struct MessageIdGenerator {
-    counter: Mutex<u16>,
+    counter: AtomicU16,
 }
 
 impl MessageIdGenerator {
@@ -32,28 +33,23 @@ impl MessageIdGenerator {
     pub fn new() -> Self {
         info!("Initializing MessageIdGenerator with starting value 0x0001");
         Self {
-            counter: Mutex::new(0x0001),
+            counter: AtomicU16::new(0),
         }
     }
 
     /// Get the next message ID, cycling back to 0x0001 after 0xFFFF.
     pub fn next_id(&self) -> u16 {
-        let mut counter = self.counter.lock().unwrap();
-        let current_id = *counter;
+        loop {
+            // Update the counter using modulo 2^16 but not 0 (atomics always wrap)
+            let id = self.counter.fetch_add(1, Ordering::Relaxed);
+            if id == 0 {
+                continue;
+            }
 
-        // Log the generated ID
-        debug!("Generated Message ID: {:#06X}", current_id);
-
-        // Update the counter using modulo 2^16
-        let check = counter.overflowing_add(1);
-        *counter = check.0;
-
-        // After overflow correct the value to 1
-        if check.1 {
-            *counter = 0x0001;
+            // Log the generated ID
+            debug!("Generated Message ID: {id:#06X}");
+            break id;
         }
-
-        current_id
     }
 }
 

--- a/src/cmdu_message_id_generator.rs
+++ b/src/cmdu_message_id_generator.rs
@@ -39,17 +39,15 @@ impl MessageIdGenerator {
 
     /// Get the next message ID, cycling back to 0x0001 after 0xFFFF.
     pub fn next_id(&self) -> u16 {
-        loop {
-            // Update the counter using modulo 2^16 but not 0 (atomics always wrap)
-            let id = self.counter.fetch_add(1, Ordering::Relaxed);
-            if id == 0 {
-                continue;
-            }
-
-            // Log the generated ID
-            debug!("Generated Message ID: {id:#06X}");
-            break id;
+        // Update the counter using modulo 2^16 but not 0 (atomics always wrap)
+        let mut id = self.counter.fetch_add(1, Ordering::Relaxed);
+        while id == 0 {
+            id = self.counter.fetch_add(1, Ordering::Relaxed);
         }
+
+        // Log the generated ID
+        debug!("Generated Message ID: {id:#06X}");
+        id
     }
 }
 


### PR DESCRIPTION
@torrentius three tests are now failing and I need you assistance in fixing them.

all of these expect panics when parsing invalid TLVs:
- test_get_tlvs_too_short_data
- test_unknown_tlv
- test_one_tlv_after_end_of_message_tlv

what should be the correct behavior when we have an invalid TLV? should we:
- skip whole CMDU (i think this is a preferred one)
- ignore all TLVs after the invalid one and continue with processing a partial CMDU