### PR TITLE
[#15] Add single registrar per network limitation (part 1)

### DIFF
--- a/src/al_sap.rs
+++ b/src/al_sap.rs
@@ -265,8 +265,9 @@ impl AlServiceAccessPoint {
                     };
 
                     if registration_status == RegistrationResult::Success {
-                        // TODO should we set this even if registration fails?
                         self.service_type = Some(request.service_type);
+                    } else {
+                        self.service_type = None;
                     }
 
                     // Calculate AL MAC Address (Derived from Forwarding Ethernet Interface)

--- a/src/al_sap.rs
+++ b/src/al_sap.rs
@@ -234,8 +234,8 @@ impl AlServiceAccessPoint {
                             self.enabled = false;
                         }
                     };
-                    self.service_type = Some(request.service_type);
-                    match request.service_type {
+
+                    let registration_status = match request.service_type {
                         ServiceType::EasyMeshAgent => {
                             tracing::info!("ServiceType EasyMeshAgent - Might be Enrollee");
                             let db = TopologyDatabase::get_instance(
@@ -244,17 +244,30 @@ impl AlServiceAccessPoint {
                             )
                             .await;
                             db.set_local_role(Some(Role::Enrollee)).await;
+                            RegistrationResult::Success
                         }
                         ServiceType::EasyMeshController => {
                             tracing::info!("ServiceType EasyMeshController - Might be Registrar");
+
                             let db = TopologyDatabase::get_instance(
                                 get_local_al_mac(self.interface_name.clone()).unwrap(),
                                 self.interface_name.clone(),
-                            )
-                            .await;
-                            db.set_local_role(Some(Role::Registrar)).await;
+                            ).await;
+
+                            if db.find_registrar_node_al_mac().await.is_none() {
+                                db.set_local_role(Some(Role::Registrar)).await;
+                                RegistrationResult::Success
+                            } else {
+                                tracing::warn!("ServiceType EasyMeshController - Registrar already present");
+                                RegistrationResult::ControllerAlreadyInNetwork
+                            }
                         }
                     };
+
+                    if registration_status == RegistrationResult::Success {
+                        // TODO should we set this even if registration fails?
+                        self.service_type = Some(request.service_type);
+                    }
 
                     // Calculate AL MAC Address (Derived from Forwarding Ethernet Interface)
                     let al_mac = if let Some(mac) = get_local_al_mac(self.interface_name.clone()) {
@@ -267,7 +280,7 @@ impl AlServiceAccessPoint {
                     let response = AlServiceRegistrationResponse {
                         al_mac_address_local: al_mac,
                         message_id_range: (0, 65535),
-                        result: RegistrationResult::Success,
+                        result: registration_status,
                     };
 
                     let _ = self

--- a/src/cmdu_codec.rs
+++ b/src/cmdu_codec.rs
@@ -24,12 +24,13 @@ use nom::{
     bytes::complete::take,
     error::{Error, ErrorKind},
     number::complete::{be_u16, be_u8},
+    Parser,
     IResult,
 };
 
 use pnet::datalink::MacAddr;
 use std::fmt::Debug;
-
+use nom::multi::length_count;
 // Internal modules
 use crate::cmdu_reassembler::CmduReassemblyError;
 use crate::tlv_cmdu_codec::TLV;
@@ -130,6 +131,7 @@ pub enum IEEE1905TLVType {
     VendorSpecificInfo,
     SearchedRole,
     SupportedRole,
+    SupportedService,
     Unknown(u8), // To handle unknown or unsupported TLV types
 }
 
@@ -147,6 +149,7 @@ impl IEEE1905TLVType {
             0x0b => IEEE1905TLVType::VendorSpecificInfo,
             0x0d => IEEE1905TLVType::SearchedRole,
             0x0f => IEEE1905TLVType::SupportedRole,
+            0x80 => IEEE1905TLVType::SupportedService,
             _ => IEEE1905TLVType::Unknown(value), // For unrecognized types
         }
     }
@@ -164,6 +167,7 @@ impl IEEE1905TLVType {
             IEEE1905TLVType::VendorSpecificInfo => 0x0b,
             IEEE1905TLVType::SearchedRole => 0x0d,
             IEEE1905TLVType::SupportedRole => 0x0f,
+            IEEE1905TLVType::SupportedService => 0x80,
             IEEE1905TLVType::Unknown(value) => value, // Return the unknown value as-is
         }
     }
@@ -882,12 +886,14 @@ pub struct SupportedRole {
 }
 
 impl SupportedRole {
+    pub const REGISTRAR: u8 = 0x00;
+
     /// Parse `SupportedRole` from raw TLV data, ensuring the role is exactly 0x00
     pub fn parse(input: &[u8], _input_length: u16) -> IResult<&[u8], Self> {
         let (input, role_bytes) = take(1usize)(input)?;
         let role = role_bytes[0];
 
-        if role != 0x00 {
+        if role != Self::REGISTRAR {
             return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
         }
 
@@ -899,6 +905,37 @@ impl SupportedRole {
         vec![self.role]
     }
 }
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, PartialEq, Eq)]
+pub struct SupportedService {
+    pub services: Vec<u8>,
+}
+
+impl SupportedService {
+    pub const CONTROLLER: u8 = 0x00;
+    pub const AGENT: u8 = 0x01;
+
+    /// Parse `SupportedService` from raw TLV data, ensuring the role is exactly 0x00
+    pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, services) = length_count(u8, u8).parse(input)?;
+
+        Ok((input, Self { services }))
+    }
+
+    /// Serialize `SupportedService` into bytes
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+        buffer.push(self.services.len() as u8);
+        for service in self.services.iter() {
+            buffer.push(*service);
+        }
+        buffer
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CMDU {
@@ -1861,6 +1898,18 @@ pub mod tests {
     }
 
     #[test]
+    fn test_supported_service_parse_and_serialize() {
+        let original = SupportedService {
+            services: vec![SupportedService::CONTROLLER, SupportedService::AGENT],
+        };
+
+        let serialized = original.serialize();
+        let parsed = SupportedService::parse(&serialized);
+
+        assert_eq!(original, parsed.unwrap().1);
+    }
+
+    #[test]
     fn test_unknown_cmdus() {
         let unknown_tlvs: Vec<TLV> = (0..6)
             .map(|i| TLV {
@@ -2456,6 +2505,7 @@ pub mod tests {
         assert_eq!(IEEE1905TLVType::from_u8(0x0b), IEEE1905TLVType::VendorSpecificInfo);
         assert_eq!(IEEE1905TLVType::from_u8(0x0d), IEEE1905TLVType::SearchedRole);
         assert_eq!(IEEE1905TLVType::from_u8(0x0f), IEEE1905TLVType::SupportedRole);
+        assert_eq!(IEEE1905TLVType::from_u8(0x80), IEEE1905TLVType::SupportedService);
     }
 
     #[test]
@@ -2471,6 +2521,7 @@ pub mod tests {
         assert_eq!(IEEE1905TLVType::VendorSpecificInfo.to_u8(), 0x0b);
         assert_eq!(IEEE1905TLVType::SearchedRole.to_u8(), 0x0d);
         assert_eq!(IEEE1905TLVType::SupportedRole.to_u8(), 0x0f);
+        assert_eq!(IEEE1905TLVType::SupportedService.to_u8(), 0x80);
     }
     #[test]
     fn test_fragmentation(){

--- a/src/cmdu_codec.rs
+++ b/src/cmdu_codec.rs
@@ -916,7 +916,7 @@ impl SupportedService {
     pub const CONTROLLER: u8 = 0x00;
     pub const AGENT: u8 = 0x01;
 
-    /// Parse `SupportedService` from raw TLV data, ensuring the role is exactly 0x00
+    /// Parse `SupportedService` from raw TLV data
     pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         use nom::number::complete::u8;
 

--- a/src/cmdu_handler.rs
+++ b/src/cmdu_handler.rs
@@ -370,7 +370,6 @@ impl CMDUHandler {
                 destination_mac: None,
                 local_interface_list: None,
                 registry_role: Some(reg_role),
-                supported_roles: vec![],
             };
 
             let _event = {
@@ -449,7 +448,6 @@ impl CMDUHandler {
                 destination_mac: None,
                 local_interface_list: None,
                 registry_role: Some(reg_role),
-                supported_roles: vec![],
             };
 
             let _event = {
@@ -535,7 +533,6 @@ impl CMDUHandler {
                 destination_mac: Some(neighbor_interface_mac_address),
                 local_interface_list: None,
                 registry_role: None,
-                supported_roles: vec![],
             };
 
             let event = topology_db
@@ -646,7 +643,6 @@ impl CMDUHandler {
                 destination_mac: Some(source_mac),
                 local_interface_list: None,
                 registry_role: None,
-                supported_roles: vec![],
             };
 
             let event = {
@@ -778,20 +774,21 @@ impl CMDUHandler {
                 TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone())
                     .await;
 
-            let supported_roles = supported_service.map(|e| e.services).unwrap_or_default().iter()
-                .filter_map(|e| match *e {
-                    SupportedService::AGENT => Some(Role::Enrollee),
-                    SupportedService::CONTROLLER => Some(Role::Registrar),
-                    _ => None,
-                })
-                .collect();
+            let registry_role = supported_service.and_then(|e| {
+                if e.services.contains(&SupportedService::CONTROLLER) {
+                    return Some(Role::Registrar);
+                }
+                if e.services.contains(&SupportedService::AGENT) {
+                    return Some(Role::Enrollee);
+                }
+                None
+            });
 
             let updated_device_data = Ieee1905DeviceData {
                 al_mac: remote_al_mac_address,
                 destination_mac: None,
                 local_interface_list: Some(interfaces.clone()),
-                registry_role: None,
-                supported_roles,
+                registry_role,
             };
 
             let event = {
@@ -892,7 +889,6 @@ impl CMDUHandler {
                 destination_mac: None,
                 local_interface_list: None,
                 registry_role: None,
-                supported_roles: vec![],
             };
 
             let event = topology_db
@@ -995,7 +991,6 @@ impl CMDUHandler {
             destination_mac: Some(destination_mac),
             local_interface_list: None,
             registry_role: None,
-            supported_roles: vec![],
         };
 
         topology_db

--- a/src/cmdu_proxy.rs
+++ b/src/cmdu_proxy.rs
@@ -424,7 +424,7 @@ pub async fn cmdu_topology_response_transmission(
             fragment: 0,
             flags: 0x80, // Not fragmented
             #[cfg(feature = "size_based_fragmentation")]
-            payload: tlv_vec.iter().flat_map(|e| e.serialize()).collect(),
+            payload: tlv_vec.iter().flat_map(TLV::serialize).collect(),
             #[cfg(not(feature = "size_based_fragmentation"))]
             payload: tlv_vec,
         };

--- a/src/device_edge_manager.rs
+++ b/src/device_edge_manager.rs
@@ -131,6 +131,7 @@ pub async fn update_edge_devices(al_mac: MacAddr, interface_name: String) {
                 destination_mac: node.device_data.destination_mac,
                 local_interface_list: Some(updated_interfaces),
                 registry_role: None,
+                supported_roles: vec![],
             };
 
             // Save updated device in the topology

--- a/src/device_edge_manager.rs
+++ b/src/device_edge_manager.rs
@@ -131,7 +131,6 @@ pub async fn update_edge_devices(al_mac: MacAddr, interface_name: String) {
                 destination_mac: node.device_data.destination_mac,
                 local_interface_list: Some(updated_interfaces),
                 registry_role: None,
-                supported_roles: vec![],
             };
 
             // Save updated device in the topology

--- a/src/registration_codec.rs
+++ b/src/registration_codec.rs
@@ -79,6 +79,7 @@ pub enum RegistrationResult {
     NoRangesAvailable = 0x02,
     ServiceNotSupported = 0x03,
     OperationNotSupported = 0x04,
+    ControllerAlreadyInNetwork = 0x5,
 }
 
 impl RegistrationResult {
@@ -90,6 +91,7 @@ impl RegistrationResult {
             0x02 => RegistrationResult::NoRangesAvailable,
             0x03 => RegistrationResult::ServiceNotSupported,
             0x04 => RegistrationResult::OperationNotSupported,
+            0x05 => RegistrationResult::ControllerAlreadyInNetwork,
             _ => return Err(nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Tag))),
         };
         Ok((input, result))
@@ -254,7 +256,7 @@ pub mod tests {
     #[test]
     #[should_panic]
     fn test_try_to_parse_inappropriate_registration_result() {
-        assert!(RegistrationResult::parse(&[5]).is_ok());
+        assert!(RegistrationResult::parse(&[6]).is_ok());
     }
 
     #[test]

--- a/src/topology_manager.rs
+++ b/src/topology_manager.rs
@@ -219,7 +219,6 @@ pub struct Ieee1905DeviceData {
     pub destination_mac: Option<MacAddr>,
     pub local_interface_list: Option<Vec<Ieee1905InterfaceData>>,
     pub registry_role: Option<Role>,
-    pub supported_roles: Vec<Role>,
 }
 
 impl Ieee1905DeviceData {
@@ -235,7 +234,6 @@ impl Ieee1905DeviceData {
             destination_mac,
             local_interface_list,
             registry_role,
-            supported_roles: vec![],
         }
     }
 
@@ -383,12 +381,9 @@ impl TopologyDatabase {
     }
 
     pub async fn find_registrar_node_al_mac(&self) -> Option<MacAddr> {
-        self.nodes
-            .read()
-            .await
-            .values()
-            .find(|e| e.device_data.registry_role == Some(Role::Registrar))
-            .map(|e| e.device_data.al_mac)
+        let nodes = self.nodes.read().await;
+        let node = nodes.values().find(|e| e.device_data.registry_role == Some(Role::Registrar));
+        Some(node?.device_data.al_mac)
     }
 
     pub async fn refresh_topology(&self) {
@@ -584,9 +579,9 @@ impl TopologyDatabase {
                                     "Comparing local_interface_list"
                                 );
 
-                                if node.device_data.supported_roles != device_data.supported_roles {
-                                    debug!("Device data changed supported roles");
-                                    node.device_data.supported_roles = device_data.supported_roles;
+                                if node.device_data.registry_role != device_data.registry_role {
+                                    debug!("Device data changed registry role");
+                                    node.device_data.registry_role = device_data.registry_role;
                                 }
 
                                 if node.device_data.local_interface_list != device_data.local_interface_list {

--- a/src/topology_manager.rs
+++ b/src/topology_manager.rs
@@ -42,7 +42,6 @@ use tui::{
 // use crate::task_registry::TASK_REGISTRY;
 // Standard library
 use std::{collections::HashMap, io, sync::Arc};
-
 // Internal modules
 use crate::{
     cmdu::IEEE1905Neighbor,
@@ -220,6 +219,7 @@ pub struct Ieee1905DeviceData {
     pub destination_mac: Option<MacAddr>,
     pub local_interface_list: Option<Vec<Ieee1905InterfaceData>>,
     pub registry_role: Option<Role>,
+    pub supported_roles: Vec<Role>,
 }
 
 impl Ieee1905DeviceData {
@@ -235,6 +235,7 @@ impl Ieee1905DeviceData {
             destination_mac,
             local_interface_list,
             registry_role,
+            supported_roles: vec![],
         }
     }
 
@@ -250,9 +251,6 @@ impl Ieee1905DeviceData {
         if let Some(interfaces) = new_interfaces {
             self.local_interface_list = Some(interfaces);
         }
-    }
-    pub fn has_changed(&self, other: &Self) -> bool {
-        self.local_interface_list != other.local_interface_list
     }
 }
 
@@ -586,7 +584,12 @@ impl TopologyDatabase {
                                     "Comparing local_interface_list"
                                 );
 
-                                if node.device_data.has_changed(&device_data) {
+                                if node.device_data.supported_roles != device_data.supported_roles {
+                                    debug!("Device data changed supported roles");
+                                    node.device_data.supported_roles = device_data.supported_roles;
+                                }
+
+                                if node.device_data.local_interface_list != device_data.local_interface_list {
                                     tracing::debug!("Device data changed local_interface_list)");
 
                                     node.device_data.update(


### PR DESCRIPTION
Done:
- added incoming cmdu filter based on current role
- added restrictions when registering our-self as a controller if another controller is already present

Next parts changes:
- tiebreaker-based local controller selection
- tiebreaker-based remote controller selection (when `ApAutoConfigResponse` is received from multiple nodes) ???
- notify other nodes that we became a controller (send notification)