### PR TITLE
chore: added changelog generation (git-cliff)

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,9 @@
+[git]
+conventional_commits = true
+filter_unconventional = false
+require_conventional = false
+commit_parsers = [
+    { message = "^chore\\(release\\):", skip = true },
+    { message = ".*", group = "Changes"},
+]
+sort_commits = "newest"

--- a/release.toml
+++ b/release.toml
@@ -1,4 +1,4 @@
-# .release.toml
+# release.toml
 
 # Only allow releases from main
 allow-branch = ["main"]
@@ -13,10 +13,9 @@ push-remote = "origin"
 
 # Commit messages
 consolidate-commits = true
+shared-version = true
+pre-release-hook = ["git-cliff", "--tag", "v{{version}}", "-o", "CHANGELOG.md"]
 pre-release-commit-message = "chore(release): {{version}}"
-
-# No automatic bump to a -dev version after release
-dev-version = false
 
 # Run checks before releasing (set to false if you don’t want tests to run)
 verify = false


### PR DESCRIPTION
git-cliff installation:
```shell
cargo install git-cliff
```

git-cliff config docs:
https://git-cliff.org/docs/configuration/git/#sort_commits

generated changelog example:
https://github.com/MatrixDev/ieee1905-rs/blob/main/CHANGELOG.md

changelog can be greatly enriched by using conventional commits:
https://www.conventionalcommits.org/en/v1.0.0/