### PR TITLE
[#54] Treat topology queries when al_mac TLV is not present

### DIFF
--- a/src/topology_manager.rs
+++ b/src/topology_manager.rs
@@ -551,13 +551,15 @@ impl TopologyDatabase {
                             let remote_state = node.metadata.node_state_remote;
 
                             if matches!((local_state, remote_state), (Some(_), Some(_))) {
-                                node.metadata.update(
-                                    Some(operation),
-                                    msg_id,
-                                    None,
-                                    None,
-                                    Some(StateRemote::ConvergingRemote),
-                                );
+                                if node.metadata.node_state_remote == Some(StateRemote::Idle) {
+                                    node.metadata.update(
+                                        Some(operation),
+                                        msg_id,
+                                        None,
+                                        None,
+                                        Some(StateRemote::ConvergingRemote),
+                                    );
+                                }
                                 tracing::debug!("Event: Send Topology Response");
                                 TransmissionEvent::SendTopologyResponse(al_mac)
                             } else {


### PR DESCRIPTION
If in received Topology Query there is no TLV with AL MAC address check if this CMDU is in Version2013. If this is Version2013 then take source MAC address as remote AL MAC address otherwise report malformed message error.

In topology manager allow transition of the node to ConvergingRemote only from Idle state as there were noticed such a temporary (fairly quick) transitions to ConvergingRemote state from ConvergedRemote: ConvergedRemote -> ConvergingRemote -> ConvergedRemote This quick temporary change to ConvergingRemote had a side effect in blocking passing Topology Query to EM agent.

Add test no. 5 to functional test to cover above circumstances.