### PR TITLE
[#63] Airties interoperability (part 1)

### DIFF
--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -127,7 +127,7 @@ pub async fn cmdu_topology_query_transmission(
     local_al_mac_address: MacAddr,
     remote_al_mac_address: MacAddr,
     interface_mac_address: MacAddr,
-    ) {
+) {
     task::spawn(async move {
         let message_id = message_id_generator.next_id();
         debug!(
@@ -222,6 +222,7 @@ pub async fn cmdu_topology_query_transmission(
                         device_data.clone(),
                         UpdateType::QuerySent,
                         Some(message_id),
+                        None,
                         None,
                     )
                     .await;
@@ -426,6 +427,7 @@ pub async fn cmdu_topology_response_transmission(
                         node.device_data.clone(),
                         UpdateType::ResponseSent,
                         Some(message_id),
+                        None,
                         None,
                     )
                     .await;

--- a/ieee1905-core/src/lldpdu_observer.rs
+++ b/ieee1905-core/src/lldpdu_observer.rs
@@ -172,6 +172,7 @@ impl EthernetFrameObserver for LLDPObserver {
                         node.device_data.clone(),
                         UpdateType::LldpUpdate,
                         None,
+                        None,
                         Some(port_id),
                     ).await;
                 } else {


### PR DESCRIPTION
Contains following changes:
- CMDU proxy will alternate CMDU discoveries of version 2013 and 2025 every 30 seconds.
- Topology manager will store the version supported by a neighbor when received a discovery.