### PR TITLE
[#74] Added parsing of NonIeee1905NeighborDevices TLV

### DIFF
--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -681,6 +681,7 @@ impl CMDUHandler {
         let mut remote_al_mac: Option<MacAddr> = None;
         let mut interfaces: Vec<Ieee1905InterfaceData> = Vec::new();
         let mut ieee_neighbors_map: HashMap<MacAddr, Vec<IEEE1905Neighbor>> = HashMap::new();
+        let mut non_ieee_neighbors_map: HashMap<MacAddr, Vec<MacAddr>> = HashMap::new();
         let mut end_of_message_found = false;
 
         for tlv in tlvs {
@@ -714,16 +715,20 @@ impl CMDUHandler {
                 }
                 IEEE1905TLVType::Ieee1905NeighborDevices => {
                     if let Some(ref value) = tlv.tlv_value {
-                        if let Ok((_, parsed)) = Ieee1905NeighborDevice::parse(
-                            value,
-                            ((tlv.tlv_length - 6) / 7) as usize,
-                        ) {
-                            ieee_neighbors_map
-                                .insert(parsed.local_mac_address, parsed.neighborhood_list);
+                        let devices_count = ((tlv.tlv_length - 6) / 7) as usize;
+                        if let Ok((_, parsed)) = Ieee1905NeighborDevice::parse(value, devices_count) {
+                            ieee_neighbors_map.insert(parsed.local_mac_address, parsed.neighborhood_list);
                         }
                     }
                 }
-                //TODO: NonIeee1905NeighborDevices
+                IEEE1905TLVType::NonIeee1905NeighborDevices => {
+                    if let Some(ref value) = tlv.tlv_value {
+                        let devices_count = (tlv.tlv_length - 6) / 6;
+                        if let Ok((_, parsed)) = NonIeee1905NeighborDevices::parse(value, devices_count) {
+                            non_ieee_neighbors_map.insert(parsed.local_mac_address, parsed.neighborhood_list);
+                        }
+                    }
+                }
                 //TODO: Bridge TUPLES only BRLAN0
                 IEEE1905TLVType::EndOfMessage => {
                     end_of_message_found = true;
@@ -738,9 +743,15 @@ impl CMDUHandler {
         }
 
         if let Some(remote_al_mac_address) = remote_al_mac {
-            let topology_db =
-                TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone())
-                    .await;
+            let topology_db = TopologyDatabase::get_instance(
+                self.local_al_mac,
+                self.interface_name.clone(),
+            ).await;
+
+            for interface in interfaces.iter_mut() {
+                interface.ieee1905_neighbors = ieee_neighbors_map.remove(&interface.mac);
+                interface.non_ieee1905_neighbors = non_ieee_neighbors_map.remove(&interface.mac);
+            }
 
             let updated_device_data = Ieee1905DeviceData {
                 al_mac: remote_al_mac_address,


### PR DESCRIPTION
Also added storage for `Ieee1905NeighborDevice`, they were previously ignored.