### PR TITLE
[#15] Added a tiebreaker-based selection of the controllers

### DIFF
--- a/ieee1905-core/src/al_sap.rs
+++ b/ieee1905-core/src/al_sap.rs
@@ -214,8 +214,8 @@ impl AlServiceAccessPoint {
                             self.enabled = false;
                         }
                     };
-                    self.service_type = Some(request.service_type);
-                    match request.service_type {
+
+                    let registration_status =match request.service_type {
                         ServiceType::EasyMeshAgent => {
                             tracing::info!("ServiceType EasyMeshAgent - Might be Enrollee");
                             let db = TopologyDatabase::get_instance(
@@ -224,17 +224,32 @@ impl AlServiceAccessPoint {
                             )
                             .await;
                             db.set_local_role(Some(Role::Enrollee)).await;
+                            RegistrationResult::Success
                         }
                         ServiceType::EasyMeshController => {
                             tracing::info!("ServiceType EasyMeshController - Might be Registrar");
+
                             let db = TopologyDatabase::get_instance(
                                 get_local_al_mac(self.interface_name.clone()).unwrap(),
                                 self.interface_name.clone(),
-                            )
-                            .await;
+                            ).await;
+
                             db.set_local_role(Some(Role::Registrar)).await;
+
+                            if db.get_actual_local_role().await == Some(Role::Registrar) {
+                                RegistrationResult::Success
+                            } else {
+                                tracing::warn!("ServiceType EasyMeshController - Registrar already present");
+                                RegistrationResult::ControllerAlreadyInNetwork
+                            }
                         }
                     };
+
+                    if registration_status == RegistrationResult::Success {
+                        self.service_type = Some(request.service_type);
+                    } else {
+                        self.service_type = None;
+                    }
 
                     // Calculate AL MAC Address (Derived from Forwarding Ethernet Interface)
                     let al_mac = if let Some(mac) = get_local_al_mac(self.interface_name.clone()) {
@@ -247,7 +262,7 @@ impl AlServiceAccessPoint {
                     let response = AlServiceRegistrationResponse {
                         al_mac_address_local: al_mac,
                         message_id_range: (0, 65535),
-                        result: RegistrationResult::Success,
+                        result: registration_status,
                     };
 
                     let _ = self
@@ -283,7 +298,7 @@ impl AlServiceAccessPoint {
             self.interface_name.clone(),
         )
         .await;
-        if let Some(local_role) = db.get_local_role().await {
+        if let Some(local_role) = db.get_actual_local_role().await {
             tracing::trace!("Compare local_role {local_role:?} with {role:?}");
             role == local_role
         } else {

--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -24,12 +24,13 @@ use nom::{
     bytes::complete::take,
     error::{Error, ErrorKind},
     number::complete::{be_u16, be_u8},
+    Parser,
     IResult,
 };
 
 use pnet::datalink::MacAddr;
 use std::fmt::Debug;
-
+use nom::multi::length_count;
 // Internal modules
 use crate::cmdu_reassembler::CmduReassemblyError;
 use crate::tlv_cmdu_codec::TLV;
@@ -134,6 +135,7 @@ pub enum IEEE1905TLVType {
     VendorSpecificInfo,
     SearchedRole,
     SupportedRole,
+    SupportedService,
     Unknown(u8), // To handle unknown or unsupported TLV types
 }
 
@@ -151,6 +153,7 @@ impl IEEE1905TLVType {
             0x0b => IEEE1905TLVType::VendorSpecificInfo,
             0x0d => IEEE1905TLVType::SearchedRole,
             0x0f => IEEE1905TLVType::SupportedRole,
+            0x80 => IEEE1905TLVType::SupportedService,
             _ => IEEE1905TLVType::Unknown(value), // For unrecognized types
         }
     }
@@ -168,6 +171,7 @@ impl IEEE1905TLVType {
             IEEE1905TLVType::VendorSpecificInfo => 0x0b,
             IEEE1905TLVType::SearchedRole => 0x0d,
             IEEE1905TLVType::SupportedRole => 0x0f,
+            IEEE1905TLVType::SupportedService => 0x80,
             IEEE1905TLVType::Unknown(value) => value, // Return the unknown value as-is
         }
     }
@@ -884,12 +888,14 @@ pub struct SupportedRole {
 }
 
 impl SupportedRole {
+    pub const REGISTRAR: u8 = 0x00;
+
     /// Parse `SupportedRole` from raw TLV data, ensuring the role is exactly 0x00
     pub fn parse(input: &[u8], _input_length: u16) -> IResult<&[u8], Self> {
         let (input, role_bytes) = take(1usize)(input)?;
         let role = role_bytes[0];
 
-        if role != 0x00 {
+        if role != Self::REGISTRAR {
             return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
         }
 
@@ -901,6 +907,38 @@ impl SupportedRole {
         vec![self.role]
     }
 }
+
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, PartialEq, Eq)]
+pub struct SupportedService {
+    pub services: Vec<u8>,
+}
+
+impl SupportedService {
+    pub const CONTROLLER: u8 = 0x00;
+    pub const AGENT: u8 = 0x01;
+
+    /// Parse `SupportedService` from raw TLV data
+    pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, services) = length_count(u8, u8).parse(input)?;
+
+        Ok((input, Self { services }))
+    }
+
+    /// Serialize `SupportedService` into bytes
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut buffer = Vec::new();
+        buffer.push(self.services.len() as u8);
+        for service in self.services.iter() {
+            buffer.push(*service);
+        }
+        buffer
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CMDU {
@@ -1265,6 +1303,10 @@ pub mod tests {
             IEEE1905TLVType::from_u8(0x0f),
             IEEE1905TLVType::SupportedRole
         );
+        assert_eq!(
+            IEEE1905TLVType::from_u8(0x80),
+            IEEE1905TLVType::SupportedService,
+        );
     }
 
     // Verify the correctness of conversion from IEEE1905TLVType enum to u8
@@ -1282,6 +1324,7 @@ pub mod tests {
         assert_eq!(IEEE1905TLVType::VendorSpecificInfo.to_u8(), 0x0b);
         assert_eq!(IEEE1905TLVType::SearchedRole.to_u8(), 0x0d);
         assert_eq!(IEEE1905TLVType::SupportedRole.to_u8(), 0x0f);
+        assert_eq!(IEEE1905TLVType::SupportedService.to_u8(), 0x80);
     }
 
     // Verify changing version by using set_message_version function
@@ -2260,6 +2303,18 @@ pub mod tests {
             ),
             Err(e) => panic!("Expected Failure(Verify), but got different error: {:?}", e),
         }
+    }
+
+    #[test]
+    fn test_supported_service_parse_and_serialize() {
+        let original = SupportedService {
+            services: vec![SupportedService::CONTROLLER, SupportedService::AGENT],
+        };
+
+        let serialized = original.serialize();
+        let parsed = SupportedService::parse(&serialized);
+
+        assert_eq!(original, parsed.unwrap().1);
     }
 
     // Try to serialize and parse unknown CMDU type

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -108,9 +108,13 @@ impl CMDUHandler {
         } else {
             cmdu.clone()
         };
+
+        if !self.filter_incoming_cmdu(&cmdu).await {
+            return Ok(());
+        }
+
         tracing::trace!("Dispatching CMDU {cmdu_to_process:?} source mac {source_mac:?} destination_mac {destination_mac:?}");
-        self.dispatch_cmdu(cmdu_to_process, source_mac, destination_mac)
-            .await;
+        self.dispatch_cmdu(cmdu_to_process, source_mac, destination_mac).await;
         Ok(())
     }
 
@@ -506,6 +510,7 @@ impl CMDUHandler {
         let mut ieee_neighbors_map: HashMap<MacAddr, Vec<IEEE1905Neighbor>> = HashMap::new();
         let mut non_ieee_neighbors_map: HashMap<MacAddr, Vec<MacAddr>> = HashMap::new();
         let mut device_bridging_capability = None;
+        let mut supported_service = None;
         let mut end_of_message_found = false;
         let mut device_vendor = Ieee1905DeviceVendor::Unknown;
 
@@ -584,6 +589,13 @@ impl CMDUHandler {
                         }
                     }
                 }
+                IEEE1905TLVType::SupportedService => {
+                    if let Some(value) = tlv.tlv_value.as_ref() {
+                        if let Ok((_, parsed)) = SupportedService::parse(value) {
+                            supported_service = Some(parsed);
+                        }
+                    }
+                }
                 IEEE1905TLVType::EndOfMessage => {
                     end_of_message_found = true;
                 }
@@ -658,11 +670,21 @@ impl CMDUHandler {
             }
         }
 
+        let registry_role = supported_service.and_then(|e| {
+            if e.services.contains(&SupportedService::CONTROLLER) {
+                return Some(Role::Registrar);
+            }
+            if e.services.contains(&SupportedService::AGENT) {
+                return Some(Role::Enrollee);
+            }
+            None
+        });
+
         let updated_device_data = Ieee1905DeviceData {
             al_mac: remote_al_mac_address,
             destination_mac: None,
             local_interface_list: Some(interfaces.clone()),
-            registry_role: None,
+            registry_role,
         };
 
         let event = topology_db
@@ -840,6 +862,7 @@ impl CMDUHandler {
 
         true
     }
+
     /// Handles APAutoconfigSearchCMDU
     async fn handle_ap_auto_config_search(&self, tlvs: &[TLV], message_id: u16) -> bool {
         tracing::debug!(
@@ -1101,6 +1124,31 @@ impl CMDUHandler {
             trace!("Cannot find device for {} topology_db", source_mac);
         }
         Ok(())
+    }
+
+    async fn filter_incoming_cmdu(&self, cmdu: &CMDU) -> bool {
+        let db = TopologyDatabase::get_instance(
+            self.local_al_mac,
+            self.interface_name.clone(),
+        ).await;
+
+        let role = db.get_actual_local_role().await;
+        let role_restricted_types: &[CMDUType] = match role {
+            Some(Role::Registrar) => &[CMDUType::ApAutoConfigResponse],
+            Some(Role::Enrollee) => {
+                match !db.has_remote_controllers().await {
+                    true => &[], // an agent can act as controller when controller is down
+                    false => &[CMDUType::ApAutoConfigSearch],
+                }
+            },
+            None => &[],
+        };
+
+        if role_restricted_types.contains(&CMDUType::from_u16(cmdu.message_type)) {
+            warn!("CMDU type {:04x} blocked based on the local role {role:?}", cmdu.message_type);
+            return false;
+        }
+        true
     }
 }
 

--- a/ieee1905-core/src/registration_codec.rs
+++ b/ieee1905-core/src/registration_codec.rs
@@ -79,6 +79,7 @@ pub enum RegistrationResult {
     NoRangesAvailable = 0x02,
     ServiceNotSupported = 0x03,
     OperationNotSupported = 0x04,
+    ControllerAlreadyInNetwork = 0x5,
 }
 
 impl RegistrationResult {
@@ -90,6 +91,7 @@ impl RegistrationResult {
             0x02 => RegistrationResult::NoRangesAvailable,
             0x03 => RegistrationResult::ServiceNotSupported,
             0x04 => RegistrationResult::OperationNotSupported,
+            0x05 => RegistrationResult::ControllerAlreadyInNetwork,
             _ => return Err(nom::Err::Failure(nom::error::Error::new(input, nom::error::ErrorKind::Tag))),
         };
         Ok((input, result))
@@ -374,7 +376,7 @@ pub mod tests {
     #[test]
     fn test_try_to_parse_inappropriate_registration_result() {
         // The value of 5 is not allowed (not covered in RegistrationResult enum) so expect ErrorKind::Tag error
-        if let Err(NomErr::Failure(nom::error::Error { code, .. })) = RegistrationResult::parse(&[5]) {
+        if let Err(NomErr::Failure(nom::error::Error { code, .. })) = RegistrationResult::parse(&[6]) {
             assert_eq!(code, ErrorKind::Tag);
         }
     }


### PR DESCRIPTION
One remaining question about notifications.
Currently they are sent when we change mode (agent/controller) during ResponseReceived.

But there is one more place that might change our mode - when we remove remote controller due to a timeout. I assume we also need to send notification in that case (currently not implemented). Additional notification should be added in case this assumption is correct.