### PR TITLE
decouple tokio console filtering from the main logger

### DIFF
--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -156,7 +156,7 @@ impl CMDUHandler {
                         )
                         .await
                     {
-                        error!("Error forwarding SDU from TopologyNotification interoperability (msg_id={message_id}): {e:?}");
+                        error!(%e, "Error forwarding SDU from TopologyNotification interoperability (msg_id={message_id})");
                     }
                 }
             }
@@ -175,7 +175,7 @@ impl CMDUHandler {
                         )
                         .await
                     {
-                        error!("Error forwarding SDU from TopologyQuery interoperability (msg_id={message_id}): {e:?}");
+                        error!(%e, "Error forwarding SDU from TopologyQuery interoperability (msg_id={message_id})");
                     }
                 }
             }
@@ -194,7 +194,7 @@ impl CMDUHandler {
                         )
                         .await
                     {
-                        error!("Error forwarding SDU from TopologyResponse interoperability (msg_id={message_id}): {e:?}");
+                        error!(%e, "Error forwarding SDU from TopologyResponse interoperability (msg_id={message_id})");
                     }
                 }
             }
@@ -215,7 +215,7 @@ impl CMDUHandler {
                     )
                     .await
                 {
-                    error!("Error forwarding SDU from CMDU (msg_id={message_id}): {e:?}");
+                    error!(%e, "Error forwarding SDU from CMDU (msg_id={message_id})");
                 }
             }
         }


### PR DESCRIPTION
when `tokio-console` is enabled via both `feature` and `flag`, filtering will be changed from *global* to *per-layer*.
it will also not require any filter changes to work, filters now apply only to logging.