### PR TITLE
[#191] fixed flags for logs output

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ journalctl -u ieee1905.service
 
 By default service run with topology CLI enabled, info log level, listening on ```eth0``` interface and unix sockets named ```/tmp/al_control_socket``` and ```/tmp/al_data_socket```.
 
-#### Enable topolgy CLI
+#### Enable topology CLI
 
 By default topology CLI is disabled.
 When topology CLI is enabled. Log files are saved to a file and will not appear on standard output.
@@ -471,6 +471,22 @@ When topology CLI is enabled. Log files are saved to a file and will not appear 
 ```shell
 /usr/bin/ieee1905 -t
 ```
+
+#### Console logger
+
+By default, logs will be printed to stdout. Use following command to disable stdout logging:
+```shell
+/usr/bin/ieee1905 --no-stdout-appender
+```
+
+#### File logger
+
+By default, file logger is disabled. To enable file logging use following arguments:
+```shell
+/usr/bin/ieee1905 --file-appender ./logs
+```
+
+This will write logs to the folder `./logs`. Those logs will be automatically rotated on a daily basis.
 
 #### Change log level
 


### PR DESCRIPTION
No arguments:
<img width="861" height="93" alt="Screenshot 2026-01-16 at 11 54 29" src="https://github.com/user-attachments/assets/25359b98-458a-4d4e-aa03-baeb371a70f1" />

Enabling file logger (logs folder is created):
<img width="859" height="93" alt="Screenshot 2026-01-16 at 11 58 32" src="https://github.com/user-attachments/assets/b1953953-4094-4a0f-a522-85d5c3f7cdd3" />

Disabling stdout:
<img width="507" height="42" alt="Screenshot 2026-01-16 at 12 37 54" src="https://github.com/user-attachments/assets/989a6f74-3e19-4393-804e-992e4a4ad68a" />

Help:
<img width="771" height="240" alt="Screenshot 2026-01-16 at 12 41 40" src="https://github.com/user-attachments/assets/bf1c77b8-173f-4423-aabf-5a0a2688f796" />
