### PR TITLE
[#251] added external tasks cancellations to topo node

### DIFF
--- a/ieee1905-core/src/rbus/interface_link.rs
+++ b/ieee1905-core/src/rbus/interface_link.rs
@@ -1,5 +1,7 @@
 use crate::rbus::{format_mac_address, format_media_type, peek_topology_database};
-use crate::topology_manager::{Ieee1905DeviceData, Ieee1905InterfaceData, Ieee1905Node};
+use crate::topology_manager::{
+    Ieee1905DeviceData, Ieee1905InterfaceData, Ieee1905NodeInternal,
+};
 use crate::TopologyDatabase;
 use nom::AsBytes;
 use rbus_core::RBusError;
@@ -35,9 +37,9 @@ impl RBus_InterfaceLink {
     }
 
     pub fn iter_links_by_interface<'a>(
-        nodes: impl Iterator<Item = &'a Ieee1905Node>,
+        nodes: impl Iterator<Item = &'a Ieee1905NodeInternal>,
         interface: &'a Ieee1905InterfaceData,
-    ) -> impl Iterator<Item = &'a Ieee1905Node> {
+    ) -> impl Iterator<Item = &'a Ieee1905NodeInternal> {
         nodes.filter(|e| e.device_data.local_interface_mac == interface.mac)
     }
 }

--- a/ieee1905-core/src/rbus/nt_device.rs
+++ b/ieee1905-core/src/rbus/nt_device.rs
@@ -2,7 +2,9 @@ use crate::cmdu_codec::{DeviceIdentificationType, Ieee1905ProfileVersion, Suppor
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use crate::rbus::{format_mac_address, peek_topology_database};
-use crate::topology_manager::{Ieee1905InterfaceData, Ieee1905LocalInterface, Ieee1905Node};
+use crate::topology_manager::{
+    Ieee1905InterfaceData, Ieee1905LocalInterface, Ieee1905NodeInternal,
+};
 use crate::TopologyDatabase;
 use either::Either;
 use nom::AsBytes;
@@ -128,7 +130,7 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
 ///
 pub enum RBus_Ieee1905Device_Node<'a> {
     Local(RwLockReadGuard<'a, [Ieee1905LocalInterface]>),
-    Remote(RwLockReadGuard<'a, Ieee1905Node>),
+    Remote(RwLockReadGuard<'a, Ieee1905NodeInternal>),
 }
 
 impl<'a> RBus_Ieee1905Device_Node<'a> {

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -366,12 +366,29 @@ pub struct Ieee1905Node {
     pub device_data: Ieee1905DeviceData, // Device-related information
 }
 
-impl Ieee1905Node {
+impl From<&Ieee1905NodeInternal> for Ieee1905Node {
+    fn from(value: &Ieee1905NodeInternal) -> Self {
+        Self {
+            metadata: value.metadata.clone(),
+            device_data: value.device_data.clone(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Ieee1905NodeInternal {
+    pub metadata: Ieee1905NodeInfo,
+    pub device_data: Ieee1905DeviceData,
+    _link_metrics_query_cancellation_token: Option<tokio_util::sync::DropGuard>,
+}
+
+impl Ieee1905NodeInternal {
     /// **Create a new `Ieee1905Node` instance**
     pub fn new(metadata: Ieee1905NodeInfo, device_data: Ieee1905DeviceData) -> Self {
         Self {
             metadata,
             device_data,
+            _link_metrics_query_cancellation_token: None,
         }
     }
 
@@ -397,7 +414,7 @@ pub struct TopologyDatabase {
     pub al_mac_address: Arc<RwLock<MacAddr>>,
     pub local_mac: Arc<RwLock<MacAddr>>,
     pub local_interface_list: Arc<RwLock<Option<Vec<Ieee1905LocalInterface>>>>,
-    pub nodes: Arc<RwLock<IndexMap<MacAddr, Ieee1905Node>>>,
+    pub nodes: Arc<RwLock<IndexMap<MacAddr, Ieee1905NodeInternal>>>,
     pub interface_name: Arc<RwLock<Option<String>>>,
     pub local_role: Arc<RwLock<Option<Role>>>,
 }
@@ -465,34 +482,37 @@ impl TopologyDatabase {
 
     /// **Retrieves a device node from the database**
     pub async fn get_device(&self, al_mac: MacAddr) -> Option<Ieee1905Node> {
-        let nodes = self.nodes.read().await; // Read lock
-        nodes.get(&al_mac).cloned() // Clone to return the device node
+        let nodes = self.nodes.read().await;
+        Some(nodes.get(&al_mac)?.into())
     }
 
     /// **Retrieves a device node from the database**
     pub async fn find_device_by_port(&self, mac: MacAddr) -> Option<Ieee1905Node> {
         let nodes = self.nodes.read().await;
-        Self::find_node_by_port(nodes.values(), mac).cloned()
+        Some(Self::find_node_by_port(nodes.values(), mac)?.into())
     }
 
     pub async fn lock_node_by_port_mut(
         &self,
         mac: MacAddr,
-    ) -> Option<RwLockMappedWriteGuard<'_, Ieee1905Node>> {
+    ) -> Option<RwLockMappedWriteGuard<'_, Ieee1905NodeInternal>> {
         let nodes = self.nodes.write().await;
         RwLockWriteGuard::try_map(nodes, |e| Self::find_node_by_port_mut(e.values_mut(), mac)).ok()
     }
 
-    fn find_node_by_port<'a, I>(mut iter: I, mac: MacAddr) -> Option<&'a Ieee1905Node>
+    fn find_node_by_port<'a, I>(mut iter: I, mac: MacAddr) -> Option<&'a Ieee1905NodeInternal>
     where
-        I: Iterator<Item = &'a Ieee1905Node>,
+        I: Iterator<Item = &'a Ieee1905NodeInternal>,
     {
         iter.find(|node| node.device_data.has_port(mac))
     }
 
-    fn find_node_by_port_mut<'a, I>(mut iter: I, mac: MacAddr) -> Option<&'a mut Ieee1905Node>
+    fn find_node_by_port_mut<'a, I>(
+        mut iter: I,
+        mac: MacAddr,
+    ) -> Option<&'a mut Ieee1905NodeInternal>
     where
-        I: Iterator<Item = &'a mut Ieee1905Node>,
+        I: Iterator<Item = &'a mut Ieee1905NodeInternal>,
     {
         iter.find(|node| node.device_data.has_port(mac))
     }
@@ -524,7 +544,7 @@ impl TopologyDatabase {
 
     fn update_local_neighbours_ieee1905_compatibility(
         interfaces: &mut [Ieee1905LocalInterface],
-        ieee1905_nodes: &IndexMap<MacAddr, Ieee1905Node>,
+        ieee1905_nodes: &IndexMap<MacAddr, Ieee1905NodeInternal>,
     ) {
         for interface in interfaces {
             let Some(neighbors) = interface.data.non_ieee1905_neighbors.as_mut() else {
@@ -816,7 +836,7 @@ impl TopologyDatabase {
                 None => {
                     tracing::debug!(al_mac = ?al_mac, operation = ?operation, "Node not found — inserting");
 
-                    let mut new_node = Ieee1905Node {
+                    let mut new_node = Ieee1905NodeInternal {
                         metadata: Ieee1905NodeInfo {
                             al_mac: device_data.al_mac,
                             last_update: operation,
@@ -828,6 +848,7 @@ impl TopologyDatabase {
                             node_state_remote: StateRemote::Idle,
                         },
                         device_data,
+                        _link_metrics_query_cancellation_token: None,
                     };
 
                     let node_was_crated;
@@ -899,12 +920,12 @@ impl TopologyDatabase {
                     debug!(%source, "link_metric_query — neighbor {e} not found");
                     return None;
                 };
-                vec![neighbor.clone()]
+                vec![neighbor.into()]
             }
             None => nodes
                 .iter()
                 .filter(|e| *e.0 != node_al_mac)
-                .map(|e| e.1.clone())
+                .map(|e| e.1.into())
                 .collect(),
         };
 
@@ -959,7 +980,12 @@ impl TopologyDatabase {
             let local_mac = self.al_mac_address.read().await.to_string();
 
             let interfaces = self.local_interface_list.read().await.clone();
-            let nodes = self.nodes.read().await.clone();
+            let nodes = {
+                let lock = self.nodes.read().await;
+                lock.iter()
+                    .map(|(k, v)| (*k, Ieee1905Node::from(v)))
+                    .collect::<Vec<_>>()
+            };
 
             terminal.draw(|f| {
                 let chunks = Layout::default()


### PR DESCRIPTION
- `Ieee1905Node` should be split into internal and `Clone`-able version because it now stores drop guard for the cancellation token and can no longer be `Clone`d
- `_link_metrics_query_cancellation_token` has a `_` prefix to avoid compilation errors until we actually use in a following PR