### PR TITLE
[#269] replaced redundant async/locks/unwraps from TopoDB

### DIFF
--- a/ieee1905-core/src/al_sap.rs
+++ b/ieee1905-core/src/al_sap.rs
@@ -239,21 +239,19 @@ impl AlServiceAccessPoint {
                     self.service_type = Some(request.service_type);
                     match request.service_type {
                         ServiceType::EasyMeshAgent => {
-                            tracing::info!("ServiceType EasyMeshAgent - Might be Enrollee");
+                            info!("ServiceType EasyMeshAgent - Might be Enrollee");
                             let db = TopologyDatabase::get_instance(
                                 get_local_al_mac(self.interface_name.clone()).unwrap(),
-                                self.interface_name.clone(),
-                            )
-                            .await;
+                                &self.interface_name,
+                            );
                             db.set_local_role(Some(Role::Enrollee)).await;
                         }
                         ServiceType::EasyMeshController => {
-                            tracing::info!("ServiceType EasyMeshController - Might be Registrar");
+                            info!("ServiceType EasyMeshController - Might be Registrar");
                             let db = TopologyDatabase::get_instance(
                                 get_local_al_mac(self.interface_name.clone()).unwrap(),
-                                self.interface_name.clone(),
-                            )
-                            .await;
+                                &self.interface_name,
+                            );
                             db.set_local_role(Some(Role::Registrar)).await;
                         }
                     };
@@ -302,9 +300,8 @@ impl AlServiceAccessPoint {
     pub async fn check_if_role_match(&self, role: Role) -> bool {
         let db = TopologyDatabase::get_instance(
             get_local_al_mac(self.interface_name.clone()).unwrap(),
-            self.interface_name.clone(),
-        )
-        .await;
+            &self.interface_name,
+        );
         if let Some(local_role) = db.get_local_role().await {
             tracing::trace!("Compare local_role {local_role:?} with {role:?}");
             role == local_role

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -249,8 +249,7 @@ impl CMDUHandler {
         let remote_al_mac = remote_al_mac.al_mac_address;
         let remote_interface_mac = remote_interface_mac.mac_address;
 
-        let topology_db =
-            TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone()).await;
+        let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
 
         let device_data = Ieee1905DeviceData {
             al_mac: remote_al_mac,
@@ -332,8 +331,7 @@ impl CMDUHandler {
 
         info!("Topology Query received from REMOTE_PORT_MAC={source_mac}");
 
-        let topology_db =
-            TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone()).await;
+        let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
 
         let device_data = if let Some(remote_al_mac) = AlMacAddress::find(tlvs) {
             Ieee1905DeviceData {
@@ -469,9 +467,7 @@ impl CMDUHandler {
             }
         }
 
-        let topology_db =
-            TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone()).await;
-
+        let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
         let Some(node) = topology_db.find_device_by_port(source_mac).await.clone() else {
             warn!(
                 al_mac = ?remote_al_mac,
@@ -614,8 +610,7 @@ impl CMDUHandler {
             return false;
         };
 
-        let topology_db =
-            TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone()).await;
+        let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
 
         let remote_al_mac_address = remote_al_mac_address.al_mac_address;
         let received_device_data = Ieee1905DeviceData {
@@ -688,10 +683,7 @@ impl CMDUHandler {
             return;
         };
 
-        let topology_db =
-            TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone()).await;
-
-        let result = topology_db
+        let result = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
             .handle_link_metric_query(source_mac, &query)
             .await;
 
@@ -747,8 +739,7 @@ impl CMDUHandler {
         };
 
         let transmission_event =
-            TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone())
-                .await
+            TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
                 .update_ieee1905_topology(
                     device_data,
                     UpdateType::ApAutoConfigSearch,
@@ -805,8 +796,7 @@ impl CMDUHandler {
             return error!("ApAutoConfigResponse CMDU missing SupportedFreqBand TLV");
         };
 
-        TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone())
-            .await
+        TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
             .handle_ap_auto_config_response(source_mac, supported_freq_band)
             .await;
 
@@ -828,8 +818,7 @@ impl CMDUHandler {
             return;
         };
 
-        TopologyDatabase::get_instance(self.local_al_mac, self.interface_name.clone())
-            .await
+        TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
             .handle_ap_auto_config_wcs(source_mac, &ap_capability)
             .await;
 
@@ -877,8 +866,7 @@ impl CMDUHandler {
             return debug!("Skipping SDU from CMDU as destination mac {destination_mac:?} is different as local al mac {}", self.local_al_mac);
         }
 
-        let topology_db =
-            TopologyDatabase::get_instance(source_mac, self.interface_name.clone()).await;
+        let topology_db = TopologyDatabase::get_instance(source_mac, &self.interface_name);
 
         if let Some(updated_node) = topology_db.get_device(source_mac).await {
             trace!("Node: {updated_node:?}");

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -115,8 +115,7 @@ pub async fn cmdu_topology_query_transmission(
             );
 
             // Retrieve device data from the topology database
-            let topology_db =
-                TopologyDatabase::get_instance(local_al_mac_address, interface.clone()).await;
+            let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
             let Some(node) = topology_db.get_device(remote_al_mac_address).await else {
                 debug!(
                     "Could not find node in topology database for AL_MAC={}",
@@ -227,8 +226,7 @@ pub fn cmdu_topology_response_transmission(
             );
 
             // Retrieve node information from the topology database
-            let topology_db =
-                TopologyDatabase::get_instance(local_al_mac_address, interface.clone()).await;
+            let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
             let Some(node) = topology_db.get_device(remote_al_mac_address).await else {
                 warn!(
                     "Could not find node in topology database for AL_MAC={}",
@@ -413,8 +411,7 @@ pub fn cmdu_topology_notification_transmission(
                 message_id
             );
 
-            let topology_db =
-                TopologyDatabase::get_instance(local_al_mac_address, interface.clone()).await;
+            let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
 
             let payload = [
                 TLV::from(AlMacAddress {
@@ -552,7 +549,7 @@ pub async fn cmdu_link_metric_response_transmission(
     );
 
     // Retrieve device data from the topology database
-    let topology_db = TopologyDatabase::get_instance(local_al_mac_address, interface.clone()).await;
+    let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
     let Some(node) = topology_db.get_device(remote_al_mac_address).await else {
         debug!("Could not find node in topology database for AL_MAC={remote_al_mac_address}");
         return;
@@ -677,9 +674,8 @@ pub fn cmdu_from_sdu_transmission(interface: String, sender: Arc<EthernetSender>
 
                     let topology_db = TopologyDatabase::get_instance(
                         sdu.source_al_mac_address,
-                        interface.clone(),
-                    )
-                        .await;
+                        &interface,
+                    );
 
                     trace!("Searching for destination {destination_al_mac} in topology database");
 

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -64,22 +64,21 @@ pub fn get_local_al_mac(interface_name: String) -> Option<MacAddr> {
     Some(MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x00, 0x00))
 }
 
-pub fn get_forwarding_interface_mac(interface_name: String) -> Option<MacAddr> {
+pub fn get_forwarding_interface_mac(interface_name: &str) -> MacAddr {
     // Fetch all network interfaces
     let interfaces = datalink::interfaces();
 
     // Find the first Ethernet interface (`ethX`)
     if let Some(mac_addr) = interfaces
         .iter()
-        .find(|iface| iface.name.starts_with(&interface_name))
+        .find(|iface| iface.name.starts_with(interface_name))
         .and_then(|iface| iface.mac)
-    // Extract and return MAC address if found
     {
         tracing::debug!("Ethernet interface found for forwarding {mac_addr}");
-        Some(mac_addr)
+        mac_addr
     } else {
         tracing::debug!("No Ethernet interface found for forwarding, using default.");
-        Some(MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x00, 0x00))
+        MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
     }
 }
 

--- a/ieee1905-core/src/lldpdu_observer.rs
+++ b/ieee1905-core/src/lldpdu_observer.rs
@@ -170,11 +170,8 @@ impl EthernetFrameObserver for LLDPObserver {
                     neighbor_chassis_id
                 );
 
-                let topology_db = TopologyDatabase::get_instance(
-                    self.local_chassis_id,
-                    self.interface_name.clone(),
-                )
-                .await;
+                let topology_db =
+                    TopologyDatabase::get_instance(self.local_chassis_id, &self.interface_name);
 
                 // If a valid port_id is found, update the topology
                 if let Some(node) = topology_db.get_device(neighbor_chassis_id).await {

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -148,7 +148,7 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
 
     // // Initialize Database
 
-    let topology_db = TopologyDatabase::get_instance(al_mac, cli.interface.clone()).await;
+    let topology_db = TopologyDatabase::get_instance(al_mac, &cli.interface);
     let _db_workers = topology_db.start_workers();
 
     // Upon every loop restart topology database role can change

--- a/ieee1905-core/src/rbus/al_device.rs
+++ b/ieee1905-core/src/rbus/al_device.rs
@@ -18,8 +18,7 @@ impl RBusProviderGetter for RBus_Al_Device {
 
         match args.path_name.as_bytes() {
             b"IEEE1905Id" => {
-                let mac_addr = db.al_mac_address.blocking_read().clone();
-                args.property.set(&format_mac_address(&mac_addr));
+                args.property.set(&format_mac_address(&db.al_mac_address));
                 Ok(())
             }
             b"InterfaceNumberOfEntries" => {


### PR DESCRIPTION
# get_forwarding_interface_mac

### Problem
- `get_forwarding_interface_mac` always returned `Some` but had `Option` in declaration.
- This required `unwrap` down the line.

### Solution
- `Option` was removed from declaration, removing the need for `uwrap`.

# TopoDB creation

### Problem
- TopoDB creation is fully synchronous but was marked as `async`.
- This required using async version of `OnceCell` and `await`-ing every time we tried to access the db.

### Solution
- Removed `async` marker from `TopoDB::new` and changed async `OnceCell` to regular `OnceLock` version.

# TopoDB locks

### Problem
- Some fields in TopoDB where hidden behind the `RwLock` while never changed.

### Solution
- Locks where removed, which simplified accessing some fields.