### PR TITLE
[#277] reduced number of tokio threads

### DIFF
--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -89,6 +89,14 @@ fn main() -> anyhow::Result<()> {
     // Start the Tokio console subscriber
     std::env::set_var("RUST_CONSOLE_BIND", "0.0.0.0:6669");
 
+    // tokio creates {available_parallelism} workers
+    // we change it to half of that (but at least 4) unless overridden from the outside
+    if std::env::var_os("TOKIO_WORKER_THREADS").is_none() {
+        let max_threads = std::thread::available_parallelism();
+        let threads = (max_threads.map_or(8, NonZeroUsize::get) / 2).max(4);
+        std::env::set_var("TOKIO_WORKER_THREADS", threads.to_string());
+    }
+
     let _guard = logger::init_logger(&cli);
     tracing::info!("Tracing initialized!");
 


### PR DESCRIPTION
Differences between versions:
| Version                | Threads | RSS (MB) |
|------------------------|---------|----------|
| QEMU ieee1905-new      | 8       | 1.872    |
| QEMU ieee1905-old      | 13      | 1.936    |
| BPI-R4 ieee1905-new    | 15      | 2.576    |
| BPI-R4 ieee1905-old    | 15      | 2.552    |
| LinuxArch ieee1905-new | 11      | 6.252    |
| LinuxArch ieee1905-old | 19      | 15.104   |

BPI-R4 has only 4 CPU cores and min number of threads set to 4, so there is no difference. Most other threads here are created as worker-per-interface.

Detailed reports are added in following comments.