### PR TITLE
[#277] added flag to disable LLDP receiver workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,14 @@ In order to analyze service with tokio-console use:
 /usr/bin/ieee1905 -c
 ```
 
+#### Disable LLDP revivers
+
+In order to disable LLDP receiver workers use:
+
+```shell
+/usr/bin/ieee1905 --no-lldp-receivers
+```
+
 #### Change unix socket
 
 Change unix sockets to ```ctrl.sock``` and ```data.sock```

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -81,6 +81,9 @@ struct CliArgs {
     /// Disable stdout appender for logs
     #[arg(long)]
     no_stdout_appender: bool,
+    /// Disable LLDP receivers
+    #[arg(long)]
+    no_lldp_receivers: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -233,14 +236,17 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
 
     for interface in get_lldp_compatible_interfaces().await {
         tracing::info!(
+            no_receiver = cli.no_lldp_receivers,
             "Starting LLDP Discovery on {}/{}",
             interface.name,
             interface.mac
         );
 
-        let mut lldp_receiver = EthernetReceiver::new();
-        lldp_receiver.subscribe(lldp_observer.clone());
-        join_sets.push(lldp_receiver.run(&interface.name)?);
+        if !cli.no_lldp_receivers {
+            let mut lldp_receiver = EthernetReceiver::new();
+            lldp_receiver.subscribe(lldp_observer.clone());
+            join_sets.push(lldp_receiver.run(&interface.name)?);
+        }
 
         let lldp_sender = EthernetSender::new(&interface.name, Arc::clone(&mutex_tx));
         tokio::task::spawn(lldp_discovery_worker(


### PR DESCRIPTION
```
> ieee1905 --help
Usage: ieee1905 [OPTIONS]

Options:
  -t, --topology-ui                          Turn on the topology text UI
  -i, --interface <INTERFACE>                Ethernet interface to be used [default: eth0]
      --sap-control-path <SAP_CONTROL_PATH>  Control socket path [default: /tmp/al_control_socket]
      --sap-data-path <SAP_DATA_PATH>        Data socket path [default: /tmp/al_data_socket]
  -f, --filter <FILTER>                      Tracing filter [default: info]
      --file-appender <FOLDER>               Enable file appender for logs
      --file-appender-files-count <COUNT>    Files written before rollover [default: 5]
      --file-appender-max-file-size <SIZE>   Max log file size (MB) [default: 5]
      --no-stdout-appender                   Disable stdout appender for logs
      --no-lldp-receivers                    Disable LLDP receivers
  -h, --help                                 Print help
  -V, --version                              Print version
```