### PR TITLE
[#289] Implemented function to get ethernet(eth*) interfaces

### DIFF
--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -660,9 +660,40 @@ struct EthernetInterfaceInfo {
 }
 
 async fn get_ethernet_interfaces(links: &[LinkInterfaceInfo]) -> Vec<Ieee1905LocalInterface> {
-    // reference impl -> get_lan_interfaces
-    let _ = links;
-    vec!()
+    let mut interfaces = Vec::new();
+
+    for link in links {
+        if !link.if_name.starts_with("eth") {
+            continue;
+        }
+
+        let data = Ieee1905InterfaceData {
+            mac: link.mac,
+            media_type: MediaType::ETHERNET_802_3ab,
+            media_type_extra: Default::default(),
+            bridging_flag: link.bridge_if_index.is_some(),
+            bridging_tuple: link.bridge_if_index,
+            vlan: link.vlan_id,
+            metric: None,
+            phy_rate: None,
+            link_availability: None,
+            signal_strength_dbm: None,
+            non_ieee1905_neighbors: Some(link.neighbours.clone()),
+            ieee1905_neighbors: None,
+        };
+
+        interfaces.push(Ieee1905LocalInterface {
+            name: link.if_name.clone(),
+            index: link.if_index,
+            flags: link.if_flags,
+            link_stats: link.link_stats,
+            data,
+        });
+    }
+
+    tracing::debug!(?interfaces, "ethernet interfaces:");
+
+    interfaces
 }
 
 async fn get_lan_interfaces() -> anyhow::Result<Vec<EthernetInterfaceInfo>> {


### PR DESCRIPTION
Implemented function to get ethernet(eth*) interfaces

```
2026-03-05T11:51:37.823691Z DEBUG topo_db_refresh_interfaces{task=2}: ieee1905::interface_manager: ethernet interfaces: interfaces=[Ieee1905LocalInterface { name: "eth1", index: 6, flags: Iff(69699), link_stats: Some(RtnlLinkStats64 { rx_packets: 74886, tx_packets: 24370, rx_bytes: 101546456, tx_bytes: 3448212, rx_errors: 0, tx_errors: 0, rx_dropped: 0, tx_dropped: 0, multicast: 0, collisions: 0, rx_length_errors: 0, rx_over_errors: 0, rx_crc_errors: 0, rx_frame_errors: 0, rx_fifo_errors: 0, rx_missed_errors: 0, tx_aborted_errors: 0, tx_carrier_errors: 0, tx_fifo_errors: 0, tx_heartbeat_errors: 0, tx_window_errors: 0, rx_compressed: 0, tx_compressed: 0, rx_no_handler: 0 }), data: Ieee1905InterfaceData { mac: 5a:ba:a3:22:80:db, media_type: MediaType(0001), media_type_extra: Other([]), bridging_flag: false, bridging_tuple: None, vlan: None, metric: None, phy_rate: None, link_availability: None, signal_strength_dbm: None, non_ieee1905_neighbors: Some([]), ieee1905_neighbors: None } }, Ieee1905LocalInterface { name: "eth2", index: 7, flags: Iff(4099), link_stats: Some(RtnlLinkStats64 { rx_packets: 0, tx_packets: 0, rx_bytes: 0, tx_bytes: 0, rx_errors: 0, tx_errors: 0, rx_dropped: 0, tx_dropped: 0, multicast: 0, collisions: 0, rx_length_errors: 0, rx_over_errors: 0, rx_crc_errors: 0, rx_frame_errors: 0, rx_fifo_errors: 0, rx_missed_errors: 0, tx_aborted_errors: 0, tx_carrier_errors: 0, tx_fifo_errors: 0, tx_heartbeat_errors: 0, tx_window_errors: 0, rx_compressed: 0, tx_compressed: 0, rx_no_handler: 0 }), data: Ieee1905InterfaceData { mac: ca:9e:94:00:a2:b1, media_type: MediaType(0001), media_type_extra: Other([]), bridging_flag: false, bridging_tuple: None, vlan: None, metric: None, phy_rate: None, link_availability: None, signal_strength_dbm: None, non_ieee1905_neighbors: Some([]), ieee1905_neighbors: None } }, Ieee1905LocalInterface { name: "eth3", index: 8, flags: Iff(4099), link_stats: Some(RtnlLinkStats64 { rx_packets: 0, tx_packets: 0, rx_bytes: 0, tx_bytes: 0, rx_errors: 0, tx_errors: 0, rx_dropped: 0, tx_dropped: 0, multicast: 0, collisions: 0, rx_length_errors: 0, rx_over_errors: 0, rx_crc_errors: 0, rx_frame_errors: 0, rx_fifo_errors: 0, rx_missed_errors: 0, tx_aborted_errors: 0, tx_carrier_errors: 0, tx_fifo_errors: 0, tx_heartbeat_errors: 0, tx_window_errors: 0, rx_compressed: 0, tx_compressed: 0, rx_no_handler: 0 }), data: Ieee1905InterfaceData { mac: fe:38:c9:7b:b1:0f, media_type: MediaType(0001), media_type_extra: Other([]), bridging_flag: false, bridging_tuple: None, vlan: None, metric: None, phy_rate: None, link_availability: None, signal_strength_dbm: None, non_ieee1905_neighbors: Some([]), ieee1905_neighbors: None } }]
```