### PR TITLE
[#289] Implemented function to get ethernet(eth*) interfaces

### DIFF
--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -116,7 +116,10 @@ pub async fn get_interfaces() -> anyhow::Result<Vec<Ieee1905LocalInterface>> {
         Err(e) => error!(%e, "get_wireless_interfaces failed"),
     }
 
-    interfaces.extend(get_ethernet_interfaces(&links).await);
+    match get_ethernet_interfaces(&links).await {
+        Ok(e) => interfaces.extend(e),
+        Err(e) => error!(%e, "get_ethernet_interfaces failed"),
+    }
 
     trace!("get_interfaces => {interfaces:#?}");
     Ok(interfaces)
@@ -641,10 +644,62 @@ struct EthernetInterfaceInfo {
     link_speed: Option<u64>,
 }
 
-async fn get_ethernet_interfaces(links: &[LinkInterfaceInfo]) -> Vec<Ieee1905LocalInterface> {
-    // reference impl -> get_lan_interfaces
-    let _ = links;
-    vec![]
+fn get_ethernet_media_type(speed: Option<u64>) -> MediaType {
+    match speed {
+        Some(rate) if rate >= 1_000_000_000 => MediaType::ETHERNET_802_3ab,
+        Some(_) => MediaType::ETHERNET_802_3u,
+        None => MediaType::ETHERNET_802_3u,
+    }
+}
+
+async fn get_ethernet_interfaces(
+    links: &[LinkInterfaceInfo],
+) -> anyhow::Result<Vec<Ieee1905LocalInterface>> {
+    let (router, _) = NlRouter::connect(NlFamily::Generic, None, Groups::empty()).await?;
+    let eth_tool_family_id = router.resolve_genl_family(ETH_TOOL_GENL_NAME).await?;
+
+    let ethtool_interfaces = call_eth_tool_get_link_modes(&router, eth_tool_family_id).await?;
+    let speed_map: IndexMap<i32, Option<u64>> = ethtool_interfaces
+        .into_iter()
+        .map(|i| (i.if_index, i.link_speed))
+        .collect();
+
+    let mut result = Vec::new();
+
+    for link in links {
+        if !link.if_name.starts_with("eth") {
+            continue;
+        }
+
+        let phy_rate = speed_map.get(&link.if_index).copied().flatten();
+
+        let local_interface_data = Ieee1905InterfaceData {
+            mac: link.mac,
+            media_type: get_ethernet_media_type(phy_rate),
+            media_type_extra: Default::default(),
+            bridging_flag: link.bridge_if_index.is_some(),
+            bridging_tuple: link.bridge_if_index,
+            vlan: link.vlan_id,
+            metric: None,
+            phy_rate,
+            link_availability: None,
+            signal_strength_dbm: None,
+            non_ieee1905_neighbors: Some(link.neighbours.clone()),
+            ieee1905_neighbors: None,
+        };
+
+        let local_interface = Ieee1905LocalInterface {
+            name: link.if_name.clone(),
+            index: link.if_index,
+            flags: link.if_flags,
+            link_stats: link.link_stats,
+            data: local_interface_data,
+        };
+
+        result.push(local_interface);
+    }
+
+    Ok(result)
 }
 
 async fn get_lan_interfaces() -> anyhow::Result<Vec<EthernetInterfaceInfo>> {


### PR DESCRIPTION
Implemented function to get ethernet(eth*) interfaces

```
    Ieee1905LocalInterface {
        name: "eth1",
        index: 6,
        flags: Iff(
            69699,
        ),
        link_stats: Some(
            RtnlLinkStats64 {
                rx_packets: 428217,
                tx_packets: 130571,
                rx_bytes: 600846569,
                tx_bytes: 15784484,
                rx_errors: 0,
                tx_errors: 0,
                rx_dropped: 0,
                tx_dropped: 0,
                multicast: 0,
                collisions: 0,
                rx_length_errors: 0,
                rx_over_errors: 0,
                rx_crc_errors: 0,
                rx_frame_errors: 0,
                rx_fifo_errors: 0,
                rx_missed_errors: 0,
                tx_aborted_errors: 0,
                tx_carrier_errors: 0,
                tx_fifo_errors: 0,
                tx_heartbeat_errors: 0,
                tx_window_errors: 0,
                rx_compressed: 0,
                tx_compressed: 0,
                rx_no_handler: 0,
            },
        ),
        data: Ieee1905InterfaceData {
            mac: 5a:ba:a3:22:80:db,
            media_type: MediaType(0001),
            media_type_extra: Other(
                [],
            ),
            bridging_flag: false,
            bridging_tuple: None,
            vlan: None,
            metric: None,
            phy_rate: Some(
                10000000000,
            ),
            link_availability: None,
            signal_strength_dbm: None,
            non_ieee1905_neighbors: Some(
                [],
            ),
            ieee1905_neighbors: None,
        },
    },
    Ieee1905LocalInterface {
        name: "eth2",
        index: 7,
        flags: Iff(
            4099,
        ),
        link_stats: Some(
            RtnlLinkStats64 {
                rx_packets: 0,
                tx_packets: 0,
                rx_bytes: 0,
                tx_bytes: 0,
                rx_errors: 0,
                tx_errors: 0,
                rx_dropped: 0,
                tx_dropped: 0,
                multicast: 0,
                collisions: 0,
                rx_length_errors: 0,
                rx_over_errors: 0,
                rx_crc_errors: 0,
                rx_frame_errors: 0,
                rx_fifo_errors: 0,
                rx_missed_errors: 0,
                tx_aborted_errors: 0,
                tx_carrier_errors: 0,
                tx_fifo_errors: 0,
                tx_heartbeat_errors: 0,
                tx_window_errors: 0,
                rx_compressed: 0,
                tx_compressed: 0,
                rx_no_handler: 0,
            },
        ),
        data: Ieee1905InterfaceData {
            mac: ca:9e:94:00:a2:b1,
            media_type: MediaType(0000),
            media_type_extra: Other(
                [],
            ),
            bridging_flag: false,
            bridging_tuple: None,
            vlan: None,
            metric: None,
            phy_rate: None,
            link_availability: None,
            signal_strength_dbm: None,
            non_ieee1905_neighbors: Some(
                [],
            ),
            ieee1905_neighbors: None,
        },
    },
    Ieee1905LocalInterface {
        name: "eth3",
        index: 8,
        flags: Iff(
            4099,
        ),
        link_stats: Some(
            RtnlLinkStats64 {
                rx_packets: 0,
                tx_packets: 0,
                rx_bytes: 0,
                tx_bytes: 0,
                rx_errors: 0,
                tx_errors: 0,
                rx_dropped: 0,
                tx_dropped: 0,
                multicast: 0,
                collisions: 0,
                rx_length_errors: 0,
                rx_over_errors: 0,
                rx_crc_errors: 0,
                rx_frame_errors: 0,
                rx_fifo_errors: 0,
                rx_missed_errors: 0,
                tx_aborted_errors: 0,
                tx_carrier_errors: 0,
                tx_fifo_errors: 0,
                tx_heartbeat_errors: 0,
                tx_window_errors: 0,
                rx_compressed: 0,
                tx_compressed: 0,
                rx_no_handler: 0,
            },
        ),
        data: Ieee1905InterfaceData {
            mac: fe:38:c9:7b:b1:0f,
            media_type: MediaType(0000),
            media_type_extra: Other(
                [],
            ),
            bridging_flag: false,
            bridging_tuple: None,
            vlan: None,
            metric: None,
            phy_rate: None,
            link_availability: None,
            signal_strength_dbm: None,
            non_ieee1905_neighbors: Some(
                [],
            ),
            ieee1905_neighbors: None,
        },
    },

```
