### PR TITLE
[#289] Capture netlink link kind in LinkInterfaceInfo; use kind to filter ethernet interfaces

### DIFF
--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -622,7 +622,6 @@ async fn get_ethernet_interfaces(
         }
 
         let if_index = link.if_index;
-        let if_name = link.if_name.as_str();
 
         let Some(interface) = if_map.get(&if_index) else {
             continue;


### PR DESCRIPTION
Capture netlink link kind in LinkInterfaceInfo; use kind to filter ethernet interfaces

<img width="692" height="572" alt="Screenshot from 2026-03-06 18-26-32" src="https://github.com/user-attachments/assets/dd677207-9109-4857-9fc9-a7705487c532" />


[bpi_ip_link.txt](https://github.com/user-attachments/files/25799742/bpi_ip_link.txt)


