### PR TITLE
Find interface for link metric by neighbor instead of bridge

### DIFF
--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -590,8 +590,14 @@ pub async fn cmdu_link_metric_response_transmission(
     for neighbor in neighbors {
         let local_interfaces = topology_db.local_interface_list.read().await;
         let local_interfaces = local_interfaces.as_deref().unwrap_or_default();
-        let Some(interface) = local_interfaces.iter().find(|e| e.mac == source_mac) else {
-            warn!("Could not find local interface with mac {source_mac}");
+
+        let Some(interface) = local_interfaces.iter().find(|e| {
+            e.ieee1905_neighbors
+                .iter()
+                .flatten()
+                .any(|e| e.neighbor_al_mac == neighbor.device_data.destination_frame_mac)
+        }) else {
+            warn!("Could not find local interface with mac {}", neighbor.device_data.destination_frame_mac);
             continue;
         };
 


### PR DESCRIPTION
Find interface for link metric by neighbor instead of bridge

<img width="1068" height="745" alt="Screenshot from 2026-03-13 17-51-39" src="https://github.com/user-attachments/assets/cfc4b98e-16fa-4ea7-b663-ab59aea0b9fd" />

[link_metrict.zip](https://github.com/user-attachments/files/25975564/link_metrict.zip)
