### PR TITLE
Buxfix/ rbus core post-merge clippy fixes

### DIFF
--- a/rbus-core/src/rbus_handle.rs
+++ b/rbus-core/src/rbus_handle.rs
@@ -177,7 +177,7 @@ impl RBusHandle {
 
             let result = RBusHandle::run_with_raw(handle, |handle| {
                 let table_name = unsafe { CStr::from_ptr(table_name) };
-                T::sync_rows(&handle, table_name)
+                T::sync_rows(handle, table_name)
             });
 
             match result {

--- a/rbus-core/src/rbus_handle/element.rs
+++ b/rbus-core/src/rbus_handle/element.rs
@@ -198,7 +198,7 @@ impl<'a> RBusDataElement<'a> {
                     handle: property,
                     library: handle.library().clone(),
                 });
-                T::get(&handle, &property)
+                T::get(handle, &property)
             });
 
             match result {
@@ -231,7 +231,7 @@ impl<'a> RBusDataElement<'a> {
                     handle: property,
                     library: handle.library().clone(),
                 });
-                T::set(&handle, &property)
+                T::set(handle, &property)
             });
 
             match result {

--- a/rbus-core/src/rbus_handle/error.rs
+++ b/rbus-core/src/rbus_handle/error.rs
@@ -111,7 +111,7 @@ impl RBusError {
         })
     }
 
-    pub(crate) fn to_raw(self) -> rbusError_t {
+    pub(crate) fn to_raw(&self) -> rbusError_t {
         match self {
             Self::GeneralError => rbusError_t::RBUS_ERROR_BUS_ERROR,
             Self::InvalidInput => rbusError_t::RBUS_ERROR_INVALID_INPUT,
@@ -147,7 +147,7 @@ impl RBusError {
             Self::NotReadable => rbusError_t::RBUS_ERROR_NOT_READABLE,
             Self::InvalidParameterType => rbusError_t::RBUS_ERROR_INVALID_PARAMETER_TYPE,
             Self::InvalidParameterValue => rbusError_t::RBUS_ERROR_INVALID_PARAMETER_VALUE,
-            Self::Unexpected(e) => rbusError_t(e),
+            Self::Unexpected(e) => rbusError_t(*e),
         }
     }
 }

--- a/rbus-core/src/rbus_value.rs
+++ b/rbus-core/src/rbus_value.rs
@@ -21,12 +21,6 @@ pub struct RBusValue {
     pub(crate) library: RBusLibrary,
 }
 
-impl Default for RBusValue {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl RBusValue {
     ///
     /// Allocate and initialize a value to an empty state with its type set to RBUS_NONE


### PR DESCRIPTION
Post-merge clippy cleanup in rbus-core

```
$ cargo build --target aarch64-unknown-linux-gnu -p ieee1905 --features=rbus
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s

$ cargo clippy
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.14s
```