### PR TITLE
Fix interface link lookup for link metrics

### DIFF
--- a/ieee1905-core/src/rbus/interface_link.rs
+++ b/ieee1905-core/src/rbus/interface_link.rs
@@ -43,7 +43,13 @@ impl RBus_InterfaceLink {
         nodes: impl Iterator<Item = &'a Ieee1905NodeInternal>,
         interface: &'a Ieee1905InterfaceData,
     ) -> impl Iterator<Item = &'a Ieee1905NodeInternal> {
-        nodes.filter(|e| e.device_data.local_interface_mac == interface.mac)
+        nodes.filter(|node| {
+            interface
+                .ieee1905_neighbors
+                .iter()
+                .flatten()
+                .any(|neighbor| node.device_data.has_port(neighbor.neighbor_al_mac))
+        })
     }
 }
 


### PR DESCRIPTION
Fix RBUS interface link lookup by IEEE1905 neighbor instead of local interface MAC

[DM_ieee1905.txt](https://github.com/user-attachments/files/26221215/DM_ieee1905.txt)
