### PR TITLE
[#324] added link-local http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,7 +74,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -85,7 +85,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -826,6 +826,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1037,6 +1048,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -1239,6 +1261,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,13 +1294,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1296,6 +1336,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1428,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ieee1905"
@@ -1332,6 +1475,7 @@ dependencies = [
  "ratatui",
  "rbus-core",
  "rbus-provider",
+ "reqwest",
  "sd-notify",
  "thiserror 2.0.18",
  "time",
@@ -1393,11 +1537,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "ipnetwork"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf466541e9d546596ee94f9f69590f89473455f88372423e0008fc1a7daf100e"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
  "serde",
 ]
 
@@ -1409,7 +1569,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1457,6 +1617,8 @@ version = "0.3.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1520,6 +1682,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1628,7 +1796,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1705,7 +1873,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2052,6 +2220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,6 +2537,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,7 +2609,40 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -2592,8 +2850,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2629,6 +2893,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2925,20 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "terminfo"
@@ -2802,6 +3086,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2826,7 +3120,7 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2838,6 +3132,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2921,6 +3225,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3063,6 +3385,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3158,6 +3504,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3565,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3327,7 +3696,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3397,12 +3766,85 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -3493,6 +3935,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3513,10 +3984,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,10 +134,13 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
+ "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -145,10 +148,15 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
+ "tokio",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -167,6 +175,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -924,6 +933,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1295,6 +1313,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "console-subscriber",
@@ -2463,6 +2482,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +2941,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/ieee1905-core/Cargo.toml
+++ b/ieee1905-core/Cargo.toml
@@ -37,6 +37,7 @@ neli = { version = "0.7.3", features = ["async"] }
 chrono = "0.4.43"
 sd-notify = "0.4.5"
 either = "1.15.0"
+axum = "0.8.8"
 
 # RUSTSEC transitive dependency overrides
 time = ">=0.3.47"

--- a/ieee1905-core/Cargo.toml
+++ b/ieee1905-core/Cargo.toml
@@ -38,6 +38,7 @@ chrono = "0.4.43"
 sd-notify = "0.4.5"
 either = "1.15.0"
 axum = "0.8.8"
+reqwest = { version = "0.13.2", default-features = false, features = ["http2", "stream"] }
 
 # RUSTSEC transitive dependency overrides
 time = ">=0.3.47"

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -29,11 +29,13 @@ use crate::cmdu_codec::*;
 use crate::cmdu_proxy::*;
 use crate::cmdu_reassembler::CmduReassembler;
 use crate::ethernet_subject_transmission::EthernetSender;
+use crate::http::artifact_client::ArtifactClient;
 use crate::sdu_codec::SDU;
 use crate::tlv_cmdu_codec::{TLVTrait, TLV};
 use crate::topology_manager::*;
 use crate::MessageIdGenerator;
 use pnet::datalink::MacAddr;
+use tokio::sync::Mutex;
 
 ///the handler has to take care of the reassembly
 pub struct CMDUHandler {
@@ -42,6 +44,7 @@ pub struct CMDUHandler {
     local_al_mac: MacAddr,
     pub interface_name: String,
     pub reassembler: Arc<CmduReassembler>,
+    artifact_client: Option<Mutex<ArtifactClient>>,
 }
 
 impl CMDUHandler {
@@ -52,6 +55,7 @@ impl CMDUHandler {
         message_id_generator: Arc<MessageIdGenerator>,
         local_al_mac: MacAddr,
         interface_name: String,
+        artifact_client: Option<Mutex<ArtifactClient>>,
     ) -> Self {
         Self {
             sender,
@@ -59,6 +63,7 @@ impl CMDUHandler {
             local_al_mac,
             interface_name,
             reassembler: Arc::new(CmduReassembler::new()),
+            artifact_client,
         }
     }
 
@@ -510,6 +515,15 @@ impl CMDUHandler {
                 if let Some(bridge_index) = bridge_index_by_interface.get(&interface.mac) {
                     interface.bridging_flag = true;
                     interface.bridging_tuple = Some(*bridge_index);
+                }
+            }
+        }
+
+        if let Some(artifact_client) = self.artifact_client.as_ref() {
+            if let Some(ipv6) = Ipv6::find(tlvs) {
+                let mut lock = artifact_client.lock().await;
+                if let Err(e) = lock.start(ipv6.link_local_ipv6_address).await {
+                    error!(%e, "failed to start artifact client");
                 }
             }
         }
@@ -1215,6 +1229,7 @@ mod tests {
             Arc::clone(&message_id_generator),
             al_mac,
             forwarding_interface.clone(),
+            None,
         )
         .await;
 

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -325,6 +325,7 @@ async fn inject_topology_response_tlvs(
         DeviceBridgingCapability::TYPE.to_u8(),
         Ieee1905NeighborDevice::TYPE.to_u8(),
         NonIeee1905NeighborDevices::TYPE.to_u8(),
+        Ipv6::TYPE.to_u8(),
     ];
     vec.retain(|e| !filtered_types.contains(&e.tlv_type));
 
@@ -411,6 +412,15 @@ async fn inject_topology_response_tlvs(
                 neighborhood_list: neighbors.to_owned(),
             }))
         }));
+    }
+
+    // injecting Ipv6
+    if let Some(address) = db.get_artifact_server_ip_address().await {
+        vec.push(TLV::from(Ipv6 {
+            al_mac_address: db.al_mac_address,
+            link_local_ipv6_address: address,
+            additional_ipv6_addresses: vec![],
+        }))
     }
 
     vec.push(end_of_message_tlv);

--- a/ieee1905-core/src/http/artifact_client.rs
+++ b/ieee1905-core/src/http/artifact_client.rs
@@ -1,0 +1,55 @@
+use futures::StreamExt;
+use std::net::SocketAddrV6;
+use std::path::Path;
+use tokio::io::AsyncWriteExt;
+use tokio_util::io::ReaderStream;
+use tracing::{info, instrument};
+
+pub struct ArtifactClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl ArtifactClient {
+    pub fn new(if_name: &str, address: SocketAddrV6) -> anyhow::Result<Self> {
+        let client = reqwest::Client::builder().interface(if_name).build()?;
+        Ok(Self {
+            client,
+            base_url: format!("http://[{}]:{}", address.ip(), address.port()),
+        })
+    }
+
+    #[instrument(skip_all, "artifact_client/download_firmware")]
+    pub async fn download_firmware(&self, target: impl AsRef<Path>) -> anyhow::Result<()> {
+        let url = format!("{}/firmware", self.base_url);
+        info!("download_firmware: {url} -> {}", target.as_ref().display());
+
+        let response = self.client.get(url).send().await?;
+        let mut input = response.bytes_stream();
+
+        let file = tokio::fs::File::create(target).await?;
+        let mut output = tokio::io::BufWriter::new(file);
+
+        while let Some(chunk) = input.next().await {
+            output.write_all_buf(&mut chunk?).await?;
+        }
+
+        Ok(())
+    }
+
+    #[instrument(skip_all, "artifact_client/upload_file")]
+    pub async fn upload_file(&self, source: impl AsRef<Path>) -> anyhow::Result<()> {
+        let url = format!("{}/upload_file", self.base_url);
+
+        let file = tokio::fs::File::open(source).await?;
+        let stream = ReaderStream::new(file);
+
+        self.client
+            .post(url)
+            .body(reqwest::Body::wrap_stream(stream))
+            .send()
+            .await?;
+
+        Ok(())
+    }
+}

--- a/ieee1905-core/src/http/artifact_client.rs
+++ b/ieee1905-core/src/http/artifact_client.rs
@@ -1,21 +1,62 @@
+use crate::http::artifact_server::ArtifactServer;
+use crate::interface_manager::InterfaceInfo;
 use futures::StreamExt;
-use std::net::SocketAddrV6;
+use std::net::Ipv6Addr;
 use std::path::Path;
 use tokio::io::AsyncWriteExt;
 use tokio_util::io::ReaderStream;
-use tracing::{info, instrument};
+use tracing::{debug, info, instrument};
 
 pub struct ArtifactClient {
-    client: reqwest::Client,
-    base_url: String,
+    if_info: InterfaceInfo,
+    instance: Option<ArtifactClientInstance>,
 }
 
 impl ArtifactClient {
-    pub fn new(if_name: &str, address: SocketAddrV6) -> anyhow::Result<Self> {
-        let client = reqwest::Client::builder().interface(if_name).build()?;
+    pub const PORT: u16 = ArtifactServer::PORT;
+
+    pub fn new(if_info: InterfaceInfo) -> anyhow::Result<Self> {
         Ok(Self {
+            if_info,
+            instance: Default::default(),
+        })
+    }
+
+    #[instrument(skip_all, "artifact_client")]
+    pub async fn start(&mut self, ip_address: Ipv6Addr) -> anyhow::Result<()> {
+        debug!(%ip_address, "starting");
+
+        if let Some(instance) = self.instance.take() {
+            if instance.ip_address == ip_address {
+                self.instance = Some(instance);
+                info!("already started");
+                return Ok(());
+            }
+        }
+
+        info!(%ip_address, "started");
+        self.instance = Some(ArtifactClientInstance::new(&self.if_info, ip_address).await?);
+        Ok(())
+    }
+}
+
+pub struct ArtifactClientInstance {
+    ip_address: Ipv6Addr,
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl ArtifactClientInstance {
+    async fn new(if_info: &InterfaceInfo, ip_address: Ipv6Addr) -> anyhow::Result<Self> {
+        debug!("creating client");
+        let client = reqwest::Client::builder()
+            .interface(&if_info.if_name)
+            .build()?;
+
+        Ok(Self {
+            ip_address,
+            base_url: format!("http://[{}]:{}", ip_address, ArtifactClient::PORT),
             client,
-            base_url: format!("http://[{}]:{}", address.ip(), address.port()),
         })
     }
 

--- a/ieee1905-core/src/http/artifact_server.rs
+++ b/ieee1905-core/src/http/artifact_server.rs
@@ -4,12 +4,15 @@ use crate::interface_manager::{
 };
 use crate::next_task_id;
 use anyhow::bail;
-use axum::body::Body;
+use axum::body::{Body, BodyDataStream};
+use axum::extract::{DefaultBodyLimit, Request};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
+use futures::StreamExt;
 use std::net::{Ipv6Addr, SocketAddrV6};
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
 use tokio::runtime::Handle;
 use tokio::task::JoinSet;
@@ -17,22 +20,15 @@ use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, instrument};
 
 #[derive(Default)]
-pub struct LocalHttpServer {
-    instance: Option<LocalHttpServerInstance>,
+pub struct ArtifactServer {
+    instance: Option<ArtifactServerInstance>,
 }
 
-pub struct LocalHttpServerInstance {
-    runtime: Handle,
-    interface: InterfaceInfo,
-    ip_address: Ipv6Addr,
-    _join_set: JoinSet<()>,
-}
-
-impl LocalHttpServer {
+impl ArtifactServer {
     const PORT: u16 = 6666;
 
-    #[instrument(skip_all, "http_server")]
-    pub async fn start(&mut self, if_name: &str) -> anyhow::Result<&mut LocalHttpServerInstance> {
+    #[instrument(skip_all, "artifact_server")]
+    pub async fn start(&mut self, if_name: &str) -> anyhow::Result<&mut ArtifactServerInstance> {
         info!(if_name, "starting server");
 
         let Some(interface) = get_interface_info(if_name) else {
@@ -61,10 +57,11 @@ impl LocalHttpServer {
         join_set.spawn(Self::worker(listener));
 
         info!("server successfully started");
-        Ok(self.instance.insert(LocalHttpServerInstance {
+        Ok(self.instance.insert(ArtifactServerInstance {
             runtime,
             interface,
             ip_address,
+            socket_address,
             _join_set: join_set,
         }))
     }
@@ -73,12 +70,14 @@ impl LocalHttpServer {
         self.instance.take_if(|e| e.interface.if_name == if_name);
     }
 
-    #[instrument(skip_all, "http_server_worker", fields(task = next_task_id()))]
+    #[instrument(skip_all, "artifact_server/worker", fields(task = next_task_id()))]
     async fn worker(listener: TcpListener) {
         info!("worker started");
         let app = Router::new()
             .route("/", get(Self::get_root_page))
-            .route("/firmware", get(Self::get_firmware));
+            .route("/firmware", get(Self::get_firmware))
+            .route("/upload_file", post(Self::upload_file))
+            .layer(DefaultBodyLimit::max(100 * 1024 * 1024));
 
         match axum::serve(listener, app).await {
             Ok(_) => info!("worker finished"),
@@ -86,7 +85,7 @@ impl LocalHttpServer {
         }
     }
 
-    #[instrument(skip_all, "http_server/get_root_page")]
+    #[instrument(skip_all, "artifact_server/get_root_page")]
     async fn get_root_page() -> String {
         info!("requested");
         let name = env!("CARGO_PKG_NAME");
@@ -94,11 +93,11 @@ impl LocalHttpServer {
         format!("{name} {version}")
     }
 
-    #[instrument(skip_all, "http_server/get_firmware")]
+    #[instrument(skip_all, "artifact_server/get_firmware")]
     async fn get_firmware() -> Response {
         info!("requested");
 
-        let file = match tokio::fs::File::open("firmware.txt").await {
+        let file = match tokio::fs::File::open("firmware.bin").await {
             Ok(file) => file,
             Err(e) => {
                 let message = format!("Failed to read firmware: {e}");
@@ -112,9 +111,44 @@ impl LocalHttpServer {
 
         (StatusCode::OK, headers, body).into_response()
     }
+
+    #[instrument(skip_all, "artifact_server/upload_file")]
+    async fn upload_file(request: Request) -> Response {
+        async fn inner(mut stream: BodyDataStream) -> anyhow::Result<()> {
+            let mut file = tokio::fs::File::create("firmware_uploaded.bin").await?;
+
+            while let Some(chunk) = stream.next().await {
+                file.write_all(&chunk?).await?;
+            }
+            Ok(())
+        }
+
+        let stream = request.into_body().into_data_stream();
+        match inner(stream).await {
+            Ok(_) => StatusCode::NO_CONTENT.into_response(),
+            Err(e) => {
+                let message = format!("Failed to write file: {e}");
+                (StatusCode::INTERNAL_SERVER_ERROR, message).into_response()
+            }
+        }
+    }
 }
 
-impl Drop for LocalHttpServerInstance {
+pub struct ArtifactServerInstance {
+    runtime: Handle,
+    interface: InterfaceInfo,
+    ip_address: Ipv6Addr,
+    socket_address: SocketAddrV6,
+    _join_set: JoinSet<()>,
+}
+
+impl ArtifactServerInstance {
+    pub fn socket_address(&self) -> SocketAddrV6 {
+        self.socket_address
+    }
+}
+
+impl Drop for ArtifactServerInstance {
     fn drop(&mut self) {
         self.runtime.spawn(call_rt_remove_address_v6(
             self.interface.if_index,

--- a/ieee1905-core/src/http/artifact_server.rs
+++ b/ieee1905-core/src/http/artifact_server.rs
@@ -1,9 +1,7 @@
 use crate::interface_manager::{
-    call_rt_new_address_v6, call_rt_remove_address_v6, convert_mac_to_eui64, get_interface_info,
-    InterfaceInfo,
+    call_rt_new_address_v6, call_rt_remove_address_v6, convert_mac_to_eui64, InterfaceInfo,
 };
 use crate::next_task_id;
-use anyhow::bail;
 use axum::body::{Body, BodyDataStream};
 use axum::extract::{DefaultBodyLimit, Request};
 use axum::http::StatusCode;
@@ -19,55 +17,71 @@ use tokio::task::JoinSet;
 use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info, instrument};
 
-#[derive(Default)]
 pub struct ArtifactServer {
+    if_info: InterfaceInfo,
+    ip_address: Ipv6Addr,
     instance: Option<ArtifactServerInstance>,
 }
 
 impl ArtifactServer {
-    const PORT: u16 = 6666;
+    pub const PORT: u16 = 6666;
+
+    pub fn new(if_info: InterfaceInfo) -> Self {
+        let ip_address = convert_mac_to_eui64(if_info.mac);
+
+        Self {
+            if_info,
+            ip_address,
+            instance: None,
+        }
+    }
+
+    pub fn if_info(&self) -> &InterfaceInfo {
+        &self.if_info
+    }
+
+    pub fn ip_address(&self) -> Ipv6Addr {
+        self.ip_address
+    }
 
     #[instrument(skip_all, "artifact_server")]
-    pub async fn start(&mut self, if_name: &str) -> anyhow::Result<&mut ArtifactServerInstance> {
-        info!(if_name, "starting server");
+    pub async fn start(&mut self) -> anyhow::Result<()> {
+        info!("starting server");
 
-        let Some(interface) = get_interface_info(if_name) else {
-            bail!("interface {if_name} not found");
-        };
-
-        if let Some(instance) = self.instance.take() {
-            if instance.interface.mac == interface.mac {
-                info!("server already started");
-                return Ok(self.instance.insert(instance));
-            }
+        if self.instance.is_some() {
+            info!("server already started");
+            return Ok(());
         }
 
-        let runtime = Handle::try_current()?;
-        let ip_address = convert_mac_to_eui64(interface.mac);
-
-        debug!(if_name, mac = %interface.mac, %ip_address, "assigning ip address to the interface");
-        call_rt_new_address_v6(interface.if_index, ip_address).await?;
+        debug!(
+            if_name = self.if_info.if_name,
+            mac = %self.if_info.mac,
+            ip_address = %self.ip_address,
+            "assigning ip address to the interface",
+        );
+        call_rt_new_address_v6(self.if_info.if_index, self.ip_address).await?;
 
         debug!("starting tcp listener");
-        let socket_address = SocketAddrV6::new(ip_address, Self::PORT, 0, interface.if_index);
-        let listener = TcpListener::bind(socket_address).await?;
+        let runtime = Handle::try_current()?;
+        let address = SocketAddrV6::new(self.ip_address, Self::PORT, 0, self.if_info.if_index);
+        let listener = TcpListener::bind(address).await?;
 
         debug!("starting server worker");
         let mut join_set = JoinSet::new();
         join_set.spawn(Self::worker(listener));
 
         info!("server successfully started");
-        Ok(self.instance.insert(ArtifactServerInstance {
+        self.instance = Some(ArtifactServerInstance {
             runtime,
-            interface,
-            ip_address,
-            socket_address,
+            if_info: self.if_info.clone(),
+            ip_address: self.ip_address,
             _join_set: join_set,
-        }))
+        });
+        Ok(())
     }
 
     pub fn stop(&mut self, if_name: &str) {
-        self.instance.take_if(|e| e.interface.if_name == if_name);
+        self.instance.take_if(|e| e.if_info.if_name == if_name);
     }
 
     #[instrument(skip_all, "artifact_server/worker", fields(task = next_task_id()))]
@@ -136,22 +150,15 @@ impl ArtifactServer {
 
 pub struct ArtifactServerInstance {
     runtime: Handle,
-    interface: InterfaceInfo,
+    if_info: InterfaceInfo,
     ip_address: Ipv6Addr,
-    socket_address: SocketAddrV6,
     _join_set: JoinSet<()>,
-}
-
-impl ArtifactServerInstance {
-    pub fn socket_address(&self) -> SocketAddrV6 {
-        self.socket_address
-    }
 }
 
 impl Drop for ArtifactServerInstance {
     fn drop(&mut self) {
         self.runtime.spawn(call_rt_remove_address_v6(
-            self.interface.if_index,
+            self.if_info.if_index,
             self.ip_address,
         ));
     }

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -19,6 +19,7 @@
 
 #![deny(warnings)]
 
+use std::net::Ipv6Addr;
 // External crates
 use pnet::datalink::{self, MacAddr};
 
@@ -38,17 +39,29 @@ use crate::topology_manager::{Ieee1905InterfaceData, Ieee1905LocalInterface};
 use indexmap::{IndexMap, IndexSet};
 use neli::consts::nl::{GenlId, NlmF};
 use neli::consts::rtnl::{
-    Arphrd, Iff, Ifla, IflaInfo, IflaVlan, Nda, Ntf, Nud, RtAddrFamily, Rtm, Rtn,
+    Arphrd, Ifa, IfaF, Iff, Ifla, IflaInfo, IflaVlan, Nda, Ntf, Nud, RtAddrFamily, RtScope, Rtm,
+    Rtn,
 };
 use neli::consts::socket::NlFamily;
 use neli::genl::{AttrTypeBuilder, GenlAttrHandle, Genlmsghdr, GenlmsghdrBuilder, NlattrBuilder};
-use neli::nl::{NlPayload, Nlmsghdr};
+use neli::nl::{NlPayload, Nlmsghdr, NlmsghdrBuilder};
 use neli::router::asynchronous::{NlRouter, NlRouterReceiverHandle};
-use neli::rtnl::{Ifinfomsg, IfinfomsgBuilder, Ndmsg, NdmsgBuilder, RtAttrHandle};
-use neli::types::GenlBuffer;
+use neli::rtnl::{
+    Ifaddrmsg, IfaddrmsgBuilder, Ifinfomsg, IfinfomsgBuilder, Ndmsg, NdmsgBuilder, RtAttrHandle,
+    RtattrBuilder,
+};
+use neli::socket::asynchronous::NlSocketHandle;
+use neli::types::{GenlBuffer, RtBuffer};
 use neli::utils::Groups;
 use std::ops::{BitAnd, Div};
 use tracing::{error, trace, warn};
+
+#[derive(Debug, Clone)]
+pub struct InterfaceInfo {
+    pub mac: MacAddr,
+    pub if_index: u32,
+    pub if_name: String,
+}
 
 pub fn get_local_al_mac(interface_name: String) -> Option<MacAddr> {
     // Fetch all network interfaces
@@ -63,6 +76,16 @@ pub fn get_local_al_mac(interface_name: String) -> Option<MacAddr> {
     }
     tracing::debug!("No Al Mac found, using default.");
     Some(MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x00, 0x00))
+}
+
+pub fn get_interface_info(if_name: &str) -> Option<InterfaceInfo> {
+    let interfaces = datalink::interfaces();
+    let interface = interfaces.iter().find(|e| e.name == if_name)?;
+    Some(InterfaceInfo {
+        mac: interface.mac?,
+        if_index: interface.index,
+        if_name: if_name.to_string(),
+    })
 }
 
 pub fn get_forwarding_interface_mac(interface_name: &str) -> MacAddr {
@@ -275,6 +298,74 @@ async fn call_rt_get_bridge_fdb() -> anyhow::Result<IndexMap<MacAddr, IndexSet<i
             .insert(if_index);
     }
     Ok(result)
+}
+
+pub async fn call_rt_new_address_v6(if_index: u32, address: Ipv6Addr) -> anyhow::Result<()> {
+    let socket = NlSocketHandle::connect(NlFamily::Route, None, Groups::empty())?;
+
+    let rt_attrs = RtBuffer::from_iter([
+        RtattrBuilder::default()
+            .rta_type(Ifa::Local)
+            .rta_payload(address.octets())
+            .build()?,
+        RtattrBuilder::default()
+            .rta_type(Ifa::Address)
+            .rta_payload(address.octets())
+            .build()?,
+    ]);
+
+    let rt_message = IfaddrmsgBuilder::default()
+        .ifa_family(RtAddrFamily::Inet6)
+        .ifa_prefixlen(64)
+        .ifa_flags(IfaF::NODAD)
+        .ifa_scope(RtScope::Link)
+        .ifa_index(if_index)
+        .rtattrs(rt_attrs)
+        .build()?;
+
+    let rt_header = NlmsghdrBuilder::default()
+        .nl_type(Rtm::Newaddr)
+        .nl_flags(NlmF::REQUEST | NlmF::CREATE | NlmF::ACK | NlmF::EXCL)
+        .nl_payload(NlPayload::Payload(rt_message))
+        .build()?;
+
+    socket.send(&rt_header).await?;
+    socket.recv_all::<u16, Ifaddrmsg>().await?;
+    Ok(())
+}
+
+pub async fn call_rt_remove_address_v6(if_index: u32, address: Ipv6Addr) -> anyhow::Result<()> {
+    let socket = NlSocketHandle::connect(NlFamily::Route, None, Groups::empty())?;
+
+    let rt_attrs = RtBuffer::from_iter([
+        RtattrBuilder::default()
+            .rta_type(Ifa::Local)
+            .rta_payload(address.octets())
+            .build()?,
+        RtattrBuilder::default()
+            .rta_type(Ifa::Address)
+            .rta_payload(address.octets())
+            .build()?,
+    ]);
+
+    let rt_message = IfaddrmsgBuilder::default()
+        .ifa_family(RtAddrFamily::Inet6)
+        .ifa_prefixlen(64)
+        .ifa_flags(IfaF::empty())
+        .ifa_scope(RtScope::Link)
+        .ifa_index(if_index)
+        .rtattrs(rt_attrs)
+        .build()?;
+
+    let rt_header = NlmsghdrBuilder::default()
+        .nl_type(Rtm::Deladdr)
+        .nl_flags(NlmF::REQUEST | NlmF::ACK)
+        .nl_payload(NlPayload::Payload(rt_message))
+        .build()?;
+
+    socket.send(&rt_header).await?;
+    socket.recv_all::<u16, Ifaddrmsg>().await?;
+    Ok(())
 }
 
 async fn get_wireless_interfaces(
@@ -935,6 +1026,29 @@ fn convert_if_type_to_role(if_type: Option<Nl80211IfType>, frequency: u32) -> Op
     })
 }
 
+pub fn convert_mac_to_eui64(mac: MacAddr) -> Ipv6Addr {
+    Ipv6Addr::from([
+        // prefix
+        0xfe,
+        0x80,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        // eui
+        mac.0 ^ 0x02,
+        mac.1,
+        mac.2,
+        0xff,
+        0xfe,
+        mac.3,
+        mac.4,
+        mac.5,
+    ])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -975,5 +1089,13 @@ mod tests {
             assert_eq!(actual, *expected, "input: total = {total}, busy = {busy}");
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_convert_mac_to_eui64() {
+        let mac = MacAddr::from([0x9e, 0x7f, 0x24, 0x2b, 0x41, 0x86]);
+        let actual = convert_mac_to_eui64(mac);
+        let expected = Ipv6Addr::from_bits(0xfe800000000000009c7f24fffe2b4186u128);
+        assert_eq!(actual, expected);
     }
 }

--- a/ieee1905-core/src/lib.rs
+++ b/ieee1905-core/src/lib.rs
@@ -39,7 +39,6 @@ pub mod sdu_codec;
 pub mod tlv_cmdu_codec;
 pub mod tlv_lldpdu_codec;
 pub mod topology_manager;
-pub mod local_http_server;
 
 #[cfg(feature = "rbus")]
 pub mod rbus;
@@ -58,6 +57,11 @@ pub mod cmdu {
         VendorSpecificInfo, CMDU,
     };
     pub use crate::tlv_cmdu_codec::TLV;
+}
+
+pub mod http {
+    pub mod artifact_client;
+    pub mod artifact_server;
 }
 
 use std::sync::atomic::{AtomicU32, Ordering};

--- a/ieee1905-core/src/lib.rs
+++ b/ieee1905-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod sdu_codec;
 pub mod tlv_cmdu_codec;
 pub mod tlv_lldpdu_codec;
 pub mod topology_manager;
+pub mod local_http_server;
 
 #[cfg(feature = "rbus")]
 pub mod rbus;

--- a/ieee1905-core/src/local_http_server.rs
+++ b/ieee1905-core/src/local_http_server.rs
@@ -1,0 +1,124 @@
+use crate::interface_manager::{
+    call_rt_new_address_v6, call_rt_remove_address_v6, convert_mac_to_eui64, get_interface_info,
+    InterfaceInfo,
+};
+use crate::next_task_id;
+use anyhow::bail;
+use axum::body::Body;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use std::net::{Ipv6Addr, SocketAddrV6};
+use tokio::net::TcpListener;
+use tokio::runtime::Handle;
+use tokio::task::JoinSet;
+use tokio_util::io::ReaderStream;
+use tracing::{debug, error, info, instrument};
+
+#[derive(Default)]
+pub struct LocalHttpServer {
+    instance: Option<LocalHttpServerInstance>,
+}
+
+pub struct LocalHttpServerInstance {
+    runtime: Handle,
+    interface: InterfaceInfo,
+    ip_address: Ipv6Addr,
+    _join_set: JoinSet<()>,
+}
+
+impl LocalHttpServer {
+    const PORT: u16 = 6666;
+
+    #[instrument(skip_all, "http_server")]
+    pub async fn start(&mut self, if_name: &str) -> anyhow::Result<&mut LocalHttpServerInstance> {
+        info!(if_name, "starting server");
+
+        let Some(interface) = get_interface_info(if_name) else {
+            bail!("interface {if_name} not found");
+        };
+
+        if let Some(instance) = self.instance.take() {
+            if instance.interface.mac == interface.mac {
+                info!("server already started");
+                return Ok(self.instance.insert(instance));
+            }
+        }
+
+        let runtime = Handle::try_current()?;
+        let ip_address = convert_mac_to_eui64(interface.mac);
+
+        debug!(if_name, mac = %interface.mac, %ip_address, "assigning ip address to the interface");
+        call_rt_new_address_v6(interface.if_index, ip_address).await?;
+
+        debug!("starting tcp listener");
+        let socket_address = SocketAddrV6::new(ip_address, Self::PORT, 0, interface.if_index);
+        let listener = TcpListener::bind(socket_address).await?;
+
+        debug!("starting server worker");
+        let mut join_set = JoinSet::new();
+        join_set.spawn(Self::worker(listener));
+
+        info!("server successfully started");
+        Ok(self.instance.insert(LocalHttpServerInstance {
+            runtime,
+            interface,
+            ip_address,
+            _join_set: join_set,
+        }))
+    }
+
+    pub fn stop(&mut self, if_name: &str) {
+        self.instance.take_if(|e| e.interface.if_name == if_name);
+    }
+
+    #[instrument(skip_all, "http_server_worker", fields(task = next_task_id()))]
+    async fn worker(listener: TcpListener) {
+        info!("worker started");
+        let app = Router::new()
+            .route("/", get(Self::get_root_page))
+            .route("/firmware", get(Self::get_firmware));
+
+        match axum::serve(listener, app).await {
+            Ok(_) => info!("worker finished"),
+            Err(e) => error!(%e, "worker failed"),
+        }
+    }
+
+    #[instrument(skip_all, "http_server/get_root_page")]
+    async fn get_root_page() -> String {
+        info!("requested");
+        let name = env!("CARGO_PKG_NAME");
+        let version = env!("CARGO_PKG_VERSION");
+        format!("{name} {version}")
+    }
+
+    #[instrument(skip_all, "http_server/get_firmware")]
+    async fn get_firmware() -> Response {
+        info!("requested");
+
+        let file = match tokio::fs::File::open("firmware.txt").await {
+            Ok(file) => file,
+            Err(e) => {
+                let message = format!("Failed to read firmware: {e}");
+                return (StatusCode::NOT_FOUND, message).into_response();
+            }
+        };
+
+        let stream = ReaderStream::new(file);
+        let body = Body::from_stream(stream);
+        let headers = [(axum::http::header::CONTENT_TYPE, "application/octet-stream")];
+
+        (StatusCode::OK, headers, body).into_response()
+    }
+}
+
+impl Drop for LocalHttpServerInstance {
+    fn drop(&mut self) {
+        self.runtime.spawn(call_rt_remove_address_v6(
+            self.interface.if_index,
+            self.ip_address,
+        ));
+    }
+}

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -37,15 +37,15 @@ use std::num::NonZeroUsize;
 use std::path::PathBuf;
 //use ieee1905::crypto_engine::CRYPTO_CONTEXT;
 use anyhow::anyhow;
+use ieee1905::http::artifact_client::ArtifactClient;
+use ieee1905::http::artifact_server::ArtifactServer;
+use sd_notify::NotifyState;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tracing::instrument;
-
-use ieee1905::local_http_server::LocalHttpServer;
-use sd_notify::NotifyState;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -134,8 +134,12 @@ fn main() -> anyhow::Result<()> {
 async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
     let mut join_sets = Vec::new();
 
-    let mut http_server = LocalHttpServer::default();
-    http_server.start(&cli.interface).await?;
+    let mut artifact_server = ArtifactServer::default();
+    let instance = artifact_server.start(&cli.interface).await?;
+
+    let client = ArtifactClient::new(&cli.interface, instance.socket_address())?;
+    client.download_firmware("firmware_downloaded.bin").await?;
+    client.upload_file("firmware.bin").await?;
 
     //Set AL MAC & test MAC addresses
     let forwarding_interface =

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -44,6 +44,7 @@ use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tracing::instrument;
 
+use ieee1905::local_http_server::LocalHttpServer;
 use sd_notify::NotifyState;
 
 #[derive(Parser)]
@@ -132,6 +133,9 @@ fn main() -> anyhow::Result<()> {
 #[instrument(skip_all, name = "main", fields(task = next_task_id()))]
 async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
     let mut join_sets = Vec::new();
+
+    let mut http_server = LocalHttpServer::default();
+    http_server.start(&cli.interface).await?;
 
     //Set AL MAC & test MAC addresses
     let forwarding_interface =

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -21,7 +21,7 @@
 
 mod logger;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use ieee1905::al_sap::AlServiceAccessPoint;
 use ieee1905::cmdu_handler::*;
 use ieee1905::cmdu_message_id_generator::get_message_id_generator;
@@ -36,7 +36,7 @@ use ieee1905::{next_task_id, CMDUObserver};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 //use ieee1905::crypto_engine::CRYPTO_CONTEXT;
-use anyhow::anyhow;
+use anyhow::bail;
 use ieee1905::http::artifact_client::ArtifactClient;
 use ieee1905::http::artifact_server::ArtifactServer;
 use sd_notify::NotifyState;
@@ -84,6 +84,15 @@ struct CliArgs {
     /// Disable LLDP receivers
     #[arg(long)]
     no_lldp_receivers: bool,
+    /// Enables artifact server
+    #[arg(long)]
+    artifacts_sync: Option<ArtifactsSync>,
+}
+
+#[derive(ValueEnum, Debug, Clone)]
+enum ArtifactsSync {
+    Server,
+    Client,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -134,13 +143,6 @@ fn main() -> anyhow::Result<()> {
 async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
     let mut join_sets = Vec::new();
 
-    let mut artifact_server = ArtifactServer::default();
-    let instance = artifact_server.start(&cli.interface).await?;
-
-    let client = ArtifactClient::new(&cli.interface, instance.socket_address())?;
-    client.download_firmware("firmware_downloaded.bin").await?;
-    client.upload_file("firmware.bin").await?;
-
     //Set AL MAC & test MAC addresses
     let forwarding_interface =
         if let Some(iface) = get_forwarding_interface_name(cli.interface.clone()) {
@@ -152,8 +154,11 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
         };
 
     // Calculate AL MAC Address (Derived from Forwarding Ethernet Interface)
-    let al_mac = get_local_al_mac(cli.interface.clone())
-        .ok_or_else(|| anyhow!("failed to get local al mac"))?;
+    let Some(if_info) = get_interface_info(&cli.interface) else {
+        bail!("failed to get local interface {}", cli.interface);
+    };
+
+    let al_mac = if_info.mac;
     tracing::info!("AL MAC address: {}", al_mac);
 
     // // Initialize Database
@@ -170,6 +175,24 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
 
     //we initilize here the values for LLDP input parameters
     let chassis_id = al_mac;
+
+    let mut _artifact_server = None;
+    let mut artifact_client = None;
+    if let Some(artifact_sync) = cli.artifacts_sync.as_ref() {
+        match artifact_sync {
+            ArtifactsSync::Server => {
+                let mut server = ArtifactServer::new(if_info.clone());
+                server.start().await?;
+                topology_db
+                    .set_artifact_server_ip_address(Some(server.ip_address()))
+                    .await;
+                _artifact_server = Some(server);
+            }
+            ArtifactsSync::Client => {
+                artifact_client = Some(Mutex::new(ArtifactClient::new(if_info.clone())?));
+            }
+        }
+    }
 
     tracing::debug!("Topology Database initialized with AL MAC: {:?}", al_mac);
 
@@ -217,6 +240,7 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
             Arc::clone(&message_id_generator),
             al_mac,
             forwarding_interface.clone(),
+            artifact_client,
         )
         .await,
     );

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -42,10 +42,11 @@ use tracing::{debug, error, info, instrument};
 // Standard library
 use indexmap::IndexMap;
 use neli::consts::rtnl::Iff;
+use std::net::Ipv6Addr;
 use std::ops::Deref;
 use std::sync::OnceLock;
 use std::{io, sync::Arc};
-use tokio::sync::{RwLockMappedWriteGuard, RwLockWriteGuard};
+use tokio::sync::{Mutex, RwLockMappedWriteGuard, RwLockWriteGuard};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 // Internal modules
@@ -436,6 +437,7 @@ pub struct TopologyDatabase {
     pub local_interface_list: Arc<RwLock<Option<Vec<Ieee1905LocalInterface>>>>,
     pub nodes: Arc<RwLock<IndexMap<MacAddr, Ieee1905NodeInternal>>>,
     pub local_role: Arc<RwLock<Option<Role>>>,
+    artifact_server_ip_address: Mutex<Option<Ipv6Addr>>,
 }
 
 impl TopologyDatabase {
@@ -455,6 +457,7 @@ impl TopologyDatabase {
             local_interface_list: Arc::new(RwLock::new(None)),
             nodes: Arc::new(RwLock::new(IndexMap::new())),
             local_role: Arc::new(RwLock::new(None)),
+            artifact_server_ip_address: Default::default(),
         })
     }
 
@@ -478,6 +481,14 @@ impl TopologyDatabase {
     pub async fn get_forwarding_interface_mac(&self) -> MacAddr {
         let mac_guard = self.local_mac.read().await;
         *mac_guard
+    }
+
+    pub async fn get_artifact_server_ip_address(&self) -> Option<Ipv6Addr> {
+        *self.artifact_server_ip_address.lock().await
+    }
+
+    pub async fn set_artifact_server_ip_address(&self, address: Option<Ipv6Addr>) {
+        *self.artifact_server_ip_address.lock().await = address;
     }
 
     /// **Returns a globally shared `TopologyDatabase` instance (async)**
@@ -1008,10 +1019,7 @@ impl TopologyDatabase {
 
                 let top_chunks = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([
-                        Constraint::Percentage(70),
-                        Constraint::Percentage(30),
-                    ])
+                    .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
                     .split(chunks[0]);
 
                 // ─────────────────────── BLOQUE 1: TOPOLOGY MANAGER


### PR DESCRIPTION
Stats from the BPI:
```
root@Filogic-GW:~# netstat -nultp | grep 6666
tcp        0      0 fe80::1:ff:fe13:536c:6666 :::*                    LISTEN      18724/ieee1905

root@Filogic-GW:~# ip a s eth0_virt_peer
17: eth0_virt_peer@eth0_virt_end: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 02:01:00:13:53:6c brd ff:ff:ff:ff:ff:ff
    inet6 fe80::1:ff:fe13:536c/64 scope link nodad 
       valid_lft forever preferred_lft forever
    inet6 fe80::7cfb:21ff:fe9a:13a5/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
root@Filogic-GW:~#

root@Filogic-GW:~# curl -g "http://[fe80::1:ff:fe13:536c%eth0_virt_peer]:6666/"
ieee1905 0.5.0
```

Request from a PC connected to the BPI:
<img width="653" height="278" alt="image" src="https://github.com/user-attachments/assets/41c2976f-7ea3-4bdd-b209-0973717b7797" />
