### PR TITLE
migration to edition 2024

### DIFF
--- a/ieee1905-core/Cargo.toml
+++ b/ieee1905-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ieee1905"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 repository = "git@github.com:rdkcentral/ieee1905-rs.git"
 license = "Apache-2.0"
 #license-file = "LICENSE"

--- a/ieee1905-core/benches/cmdu_handler_bench.rs
+++ b/ieee1905-core/benches/cmdu_handler_bench.rs
@@ -1,5 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ieee1905::cmdu::{CMDUType, CMDU};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use ieee1905::cmdu::{CMDU, CMDUType};
 use ieee1905::cmdu_handler::CMDUHandler;
 use ieee1905::cmdu_message_id_generator::get_message_id_generator;
 use ieee1905::ethernet_subject_transmission::EthernetSender;
@@ -77,12 +77,14 @@ fn bench_handle_cmdu(c: &mut Criterion) {
 
     c.bench_function("cmdu_handler/topology_response_node_missing", |b| {
         b.to_async(&rt).iter(|| async {
-            let result = handler.handle_cmdu(
-                black_box(&cmdu),
-                black_box(src_missing),
-                black_box(dst),
-                black_box(if_mac),
-            ).await;
+            let result = handler
+                .handle_cmdu(
+                    black_box(&cmdu),
+                    black_box(src_missing),
+                    black_box(dst),
+                    black_box(if_mac),
+                )
+                .await;
             let _ = black_box(result);
         });
     });

--- a/ieee1905-core/benches/cmdu_proxy_bench.rs
+++ b/ieee1905-core/benches/cmdu_proxy_bench.rs
@@ -1,5 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use ieee1905::cmdu::{IEEE1905TLVType, TLV, CMDU};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use ieee1905::cmdu::{CMDU, IEEE1905TLVType, TLV};
 use ieee1905::cmdu_codec::{CMDUFragmentation, MessageVersion};
 
 fn build_payload(num_tlvs: usize, tlv_value_len: usize) -> Vec<u8> {

--- a/ieee1905-core/benches/cmdu_reassembler_bench.rs
+++ b/ieee1905-core/benches/cmdu_reassembler_bench.rs
@@ -1,11 +1,15 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
 use ieee1905::cmdu::CMDU;
 use ieee1905::cmdu_reassembler::CmduReassembler;
 use pnet::datalink::MacAddr;
 use std::time::Duration;
 use tokio::runtime::Runtime;
 
-fn make_fragments(message_id: u16, num_fragments: usize, fragment_payload_size: usize) -> Vec<CMDU> {
+fn make_fragments(
+    message_id: u16,
+    num_fragments: usize,
+    fragment_payload_size: usize,
+) -> Vec<CMDU> {
     (0..num_fragments)
         .map(|fragment_id| {
             let is_last = fragment_id == num_fragments - 1;
@@ -30,7 +34,13 @@ fn bench_cmdu_reassembler(c: &mut Criterion) {
     let rt = Runtime::new().expect("failed to create tokio runtime");
     let src = MacAddr::new(0x02, 0xaa, 0xbb, 0xcc, 0xdd, 0xee);
     let packet_fragments = (0..packets_per_iteration)
-        .map(|packet_id| make_fragments(0x2244 + packet_id as u16, fragments_per_packet, fragment_payload_size))
+        .map(|packet_id| {
+            make_fragments(
+                0x2244 + packet_id as u16,
+                fragments_per_packet,
+                fragment_payload_size,
+            )
+        })
         .collect::<Vec<_>>();
 
     let reassembler = rt.block_on(async { CmduReassembler::new() });

--- a/ieee1905-core/benches/codec_parse_bench.rs
+++ b/ieee1905-core/benches/codec_parse_bench.rs
@@ -1,7 +1,7 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
-use ieee1905::cmdu::{IEEE1905TLVType, TLV as CmduTlv, CMDU};
+use criterion::{Criterion, Throughput, black_box, criterion_group, criterion_main};
+use ieee1905::cmdu::{CMDU, IEEE1905TLVType, TLV as CmduTlv};
 use ieee1905::cmdu_codec::MessageVersion;
-use ieee1905::lldpdu::{LLDPTLVType, TLV as LldpTlv, LLDPDU};
+use ieee1905::lldpdu::{LLDPDU, LLDPTLVType, TLV as LldpTlv};
 
 fn build_cmdu_bytes(vendor_tlvs: usize, vendor_data_len: usize) -> Vec<u8> {
     let mut payload = Vec::new();
@@ -86,7 +86,11 @@ fn build_lldpdu_bytes(extra_tlvs: usize, tlv_value_len: usize) -> Vec<u8> {
 
 fn bench_cmdu_parse(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec_parse_cmdu");
-    let cases = [("small", 1usize, 16usize), ("medium", 8, 64), ("large", 24, 128)];
+    let cases = [
+        ("small", 1usize, 16usize),
+        ("medium", 8, 64),
+        ("large", 24, 128),
+    ];
 
     for (name, count, value_len) in cases {
         let bytes = build_cmdu_bytes(count, value_len);

--- a/ieee1905-core/src/al_sap.rs
+++ b/ieee1905-core/src/al_sap.rs
@@ -27,8 +27,8 @@ use crate::registration_codec::{
 };
 use crate::sdu_codec::SDU;
 use crate::topology_manager::Role;
-use crate::{next_task_id, TopologyDatabase};
-use anyhow::{bail, Context, Result};
+use crate::{TopologyDatabase, next_task_id};
+use anyhow::{Context, Result, bail};
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
 use lazy_static::lazy_static;
@@ -42,7 +42,7 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 use tokio_util::bytes::Bytes;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
 // Internal modules
-use crate::cmdu_codec::{CMDUFragmentation, IEEE1905TLVType, Profile2ApCapability, CMDU};
+use crate::cmdu_codec::{CMDU, CMDUFragmentation, IEEE1905TLVType, Profile2ApCapability};
 use tokio::sync::oneshot;
 
 use once_cell::sync::Lazy;
@@ -371,7 +371,9 @@ pub async fn service_access_point_data_indication(sdu: &SDU) -> Result<()> {
 
         return Ok(());
     }
-    tracing::trace!("SDU has to be fragmented SDU_PAYLOAD_SIZE: {total_size:?} MAX_PAYLOAD_SIZE: {FRAGMENT_SIZE:?}");
+    tracing::trace!(
+        "SDU has to be fragmented SDU_PAYLOAD_SIZE: {total_size:?} MAX_PAYLOAD_SIZE: {FRAGMENT_SIZE:?}"
+    );
     let num_fragments = total_size.div_ceil(FRAGMENT_SIZE);
     tracing::trace!("SDU will be fragmented into {num_fragments:?} parts");
     for i in 0..num_fragments {
@@ -579,7 +581,9 @@ pub async fn service_access_point_data_request() -> Result<SDU, AlSapError> {
                                                         || last_tlv.tlv_length != 0
                                                         || last_tlv.tlv_value.is_some()
                                                     {
-                                                        tracing::error!("ReassembleSDU: Last is not end of message");
+                                                        tracing::error!(
+                                                            "ReassembleSDU: Last is not end of message"
+                                                        );
                                                         return Err(AlSapError::Other(
                                                             "Error: last TLV is not end of message"
                                                                 .to_string(),
@@ -617,7 +621,9 @@ pub async fn service_access_point_data_request() -> Result<SDU, AlSapError> {
                 }
             }
             None => {
-                tracing::debug!("Remote unix stream side has unexpectedly closed connection in the middle of SDU fragments transmission. Dropping this incomplete SDU instead of sending it through network.");
+                tracing::debug!(
+                    "Remote unix stream side has unexpectedly closed connection in the middle of SDU fragments transmission. Dropping this incomplete SDU instead of sending it through network."
+                );
                 return Err(AlSapError::SocketClosed);
             }
         }

--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -20,13 +20,13 @@
 #![deny(warnings)]
 
 // External crates
+use nom::{Err as NomErr, Needed};
 use nom::{
+    IResult, Parser,
     bytes::complete::take,
     error::{Error, ErrorKind},
-    number::complete::{be_i8, be_u16, be_u32, be_u8},
-    IResult, Parser,
+    number::complete::{be_i8, be_u8, be_u16, be_u32},
 };
-use nom::{Err as NomErr, Needed};
 
 use anyhow::bail;
 use nom::combinator::{all_consuming, cond};
@@ -36,8 +36,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::net::Ipv6Addr;
 // Internal modules
 use crate::cmdu_reassembler::CmduReassemblyError;
-use crate::tlv_cmdu_codec::{TLVTrait, TLV};
-
+use crate::tlv_cmdu_codec::{TLV, TLVTrait};
 
 ///////////////////////////////////////////////////////////////////////////
 //DEFINITION OF CMDU TYPES and IEEE1905 TLVs
@@ -340,10 +339,8 @@ impl TLVTrait for Ipv6 {
         let (input, additional_ipv6_addresses) = count(
             |input| {
                 let (input, address_type_raw) = be_u8(input)?;
-                let address_type =
-                    IPv6AddressType::from_u8(address_type_raw).ok_or_else(|| {
-                        NomErr::Failure(Error::new(input, ErrorKind::Alt))
-                    })?;
+                let address_type = IPv6AddressType::from_u8(address_type_raw)
+                    .ok_or_else(|| NomErr::Failure(Error::new(input, ErrorKind::Alt)))?;
                 let (input, ipv6_address) = take_ipv6_addr(input)?;
                 let (input, ipv6_originator) = take_ipv6_addr(input)?;
 
@@ -1870,15 +1867,14 @@ impl CMDU {
                 return Err(NomErr::Failure(Error::new(input, ErrorKind::Tag)));
             };
             // We can check if TLV's can be parsed and last TLV is really EoF
-            if let Some(last_tlv) = tlvs.last() {
-                if last_tlv.tlv_type != IEEE1905TLVType::EndOfMessage.to_u8()
+            if let Some(last_tlv) = tlvs.last()
+                && (last_tlv.tlv_type != IEEE1905TLVType::EndOfMessage.to_u8()
                     || last_tlv.tlv_length != 0
-                    || last_tlv.tlv_value.is_some()
-                {
-                    tracing::error!("TLV: Last is not end of message");
-                    return Err(NomErr::Failure(Error::new(input, ErrorKind::Tag)));
-                }
-            };
+                    || last_tlv.tlv_value.is_some())
+            {
+                tracing::error!("TLV: Last is not end of message");
+                return Err(NomErr::Failure(Error::new(input, ErrorKind::Tag)));
+            }
         }
         tracing::trace!("Returning CMDU. Might have incomplete TLV's due to size fragmentation");
         Ok((&[], cmdu))
@@ -1923,11 +1919,11 @@ impl CMDU {
                 bail!("TLV is too large, size = {tlv_size}/{max_content_size}");
             }
 
-            if let Some(fragment) = fragments.last_mut() {
-                if fragment.payload.len() + tlv_size <= max_content_size {
-                    fragment.payload.extend(tlv.serialize());
-                    continue;
-                }
+            if let Some(fragment) = fragments.last_mut()
+                && fragment.payload.len() + tlv_size <= max_content_size
+            {
+                fragment.payload.extend(tlv.serialize());
+                continue;
             }
 
             fragments.push(Self {
@@ -2478,7 +2474,7 @@ pub mod tests {
                 } else {
                     // Last CMDU fragment which is not first one - in case of size based fragmentation should have minimal size of CMDU header + 1 byte
                     assert!(
-                        frag.total_size() >= 8 + 1,
+                        frag.total_size() > 8,
                         "Fragment {0} should be at least 8+1 bytes but is {1} bytes long",
                         i,
                         frag.total_size()
@@ -2537,7 +2533,8 @@ pub mod tests {
         assert!(
             fragments[0].total_size() >= 8 + 3,
             "Empty CMDU payload. CMDU fragment should be at least 8+3 bytes (CMDU header + endOfMessageTlv) but is {:?} bytes long",
-            fragments[0].total_size());
+            fragments[0].total_size()
+        );
 
         // Check if total size of CMDU meets requirement of maximal size of the fragment
         assert!(
@@ -3188,7 +3185,10 @@ pub mod tests {
         // Parse the BridgingTuple data
         let bridging_tuple = BridgingTuple::parse(bridging_tuple_data).unwrap().1;
         assert_eq!(bridging_tuple.bridging_mac_count, 1);
-        assert_eq!(bridging_tuple.bridging_mac_list[0], [0x02, 0x42, 0xc0, 0xa8, 0x64, 0x02]);
+        assert_eq!(
+            bridging_tuple.bridging_mac_list[0],
+            [0x02, 0x42, 0xc0, 0xa8, 0x64, 0x02]
+        );
 
         // Serialize just parsed BridgingTuple structure
         let serialized = bridging_tuple.serialize();
@@ -3359,8 +3359,8 @@ pub mod tests {
     // Try to serialize and parse AP autoconfig search CMDU with invalid role
     #[test]
     fn test_ap_autoconfig_search_with_invalid_role_should_fail() {
-        use nom::error::ErrorKind;
         use nom::Err;
+        use nom::error::ErrorKind;
 
         let searched_role_value = SearchedRole { role: 0x01 };
         let searched_role_tlv = TLV {
@@ -4013,7 +4013,7 @@ pub mod tests {
                 } else {
                     // Last CMDU fragment which is not first one - in case of size based fragmentation should have minimal size of CMDU header + 1 byte
                     assert!(
-                        frag.total_size() >= 8 + 1,
+                        frag.total_size() > 8,
                         "Fragment {0} should be at least 8+1 bytes but is {1} bytes long",
                         i,
                         frag.total_size()
@@ -4179,7 +4179,7 @@ pub mod tests {
         let mut offset = 0;
 
         // Define vector of sizes of consecutive TLVs for verification (from already sorted CMDUs)
-        let sizes = vec![10, 20, 30, 40, 50, 60];
+        let sizes = [10, 20, 30, 40, 50, 60];
 
         // Iter on all the TLVs and check their size with the predefined vector "sizes"
         for i in sizes.iter() {

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -974,7 +974,7 @@ mod tests {
                 } else {
                     // Last CMDU fragment which is not first one - in case of size based fragmentation should have minimal size of CMDU header + 1 byte
                     assert!(
-                        fragment.total_size() >= 8 + 1,
+                        fragment.total_size() > 8,
                         "Fragment {0} should be at least 8+1 bytes but is {1} bytes long",
                         i,
                         fragment.total_size()
@@ -1142,7 +1142,7 @@ mod tests {
                 } else {
                     // Last CMDU fragment which is not first one - in case of size based fragmentation should have minimal size of CMDU header + 1 byte
                     assert!(
-                        fragment.total_size() >= 8 + 1,
+                        fragment.total_size() > 8,
                         "Fragment {0} should be at least 8+1 bytes but is {1} bytes long",
                         i,
                         fragment.total_size()
@@ -1244,7 +1244,7 @@ mod tests {
         cmdu2.flags = 0x80; // set last fragment flag
 
         let source_mac = MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66);
-        let fragments = vec![cmdu0, cmdu1, cmdu2];
+        let fragments = [cmdu0, cmdu1, cmdu2];
         let cmdu_reasm = CmduReassembler::new();
 
         for fragment in fragments.iter() {

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -23,16 +23,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, error, info, instrument, trace, warn};
 
-use crate::al_sap::{service_access_point_data_indication, AlServiceAccessPoint};
-use crate::cmdu::{CMDUType, CMDU};
+use crate::MessageIdGenerator;
+use crate::al_sap::{AlServiceAccessPoint, service_access_point_data_indication};
+use crate::cmdu::{CMDU, CMDUType};
 use crate::cmdu_codec::*;
 use crate::cmdu_proxy::*;
 use crate::cmdu_reassembler::CmduReassembler;
 use crate::ethernet_subject_transmission::EthernetSender;
 use crate::sdu_codec::SDU;
-use crate::tlv_cmdu_codec::{TLVTrait, TLV};
+use crate::tlv_cmdu_codec::{TLV, TLVTrait};
 use crate::topology_manager::*;
-use crate::MessageIdGenerator;
 use pnet::datalink::MacAddr;
 
 ///the handler has to take care of the reassembly
@@ -235,7 +235,9 @@ impl CMDUHandler {
         );
 
         if EndOfMessage::find(tlvs).is_none() {
-            return error!("Topology Discovery CMDU is missing the required End of Message TLV. Ignoring CMDU.");
+            return error!(
+                "Topology Discovery CMDU is missing the required End of Message TLV. Ignoring CMDU."
+            );
         }
 
         let Some(remote_al_mac) = AlMacAddress::find(tlvs) else {
@@ -865,7 +867,10 @@ impl CMDUHandler {
         }
 
         if destination_mac != IEEE1905_CONTROL_ADDRESS && destination_mac != self.local_al_mac {
-            return debug!("Skipping SDU from CMDU as destination mac {destination_mac:?} is different as local al mac {}", self.local_al_mac);
+            return debug!(
+                "Skipping SDU from CMDU as destination mac {destination_mac:?} is different as local al mac {}",
+                self.local_al_mac
+            );
         }
 
         let topology_db = TopologyDatabase::get_instance(source_mac, &self.interface_name);
@@ -1226,10 +1231,12 @@ mod tests {
         let destination_mac = MacAddr::new(0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc);
 
         // Expect panic in handle_cmdu() as the CMDU size is prepared to have 1501 bytes
-        assert!(cmdu_handler
-            .handle_cmdu(&cmdu, source_mac, destination_mac, destination_mac)
-            .await
-            .is_err());
+        assert!(
+            cmdu_handler
+                .handle_cmdu(&cmdu, source_mac, destination_mac, destination_mac)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/ieee1905-core/src/cmdu_message_id_generator.rs
+++ b/ieee1905-core/src/cmdu_message_id_generator.rs
@@ -18,8 +18,8 @@
 */
 
 #![deny(warnings)]
-use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU16, Ordering};
 use tokio::sync::OnceCell;
 use tracing::{debug, info}; // Import tracing
 

--- a/ieee1905-core/src/cmdu_message_id_generator.rs
+++ b/ieee1905-core/src/cmdu_message_id_generator.rs
@@ -82,22 +82,22 @@ pub mod tests {
     // and u16 type overflow handling
     #[tokio::test]
     async fn test_check_message_id_value_overflow() {
-        let gen = get_message_id_generator().await;
+        let id_gen = get_message_id_generator().await;
 
-        assert_eq!(gen.next_id(), 1);
-        assert_eq!(gen.next_id(), 2);
+        assert_eq!(id_gen.next_id(), 1);
+        assert_eq!(id_gen.next_id(), 2);
 
         // Rewind u16 type values to the value of 0xFFFE (near the last value of u16)
         for _i in 0u32..(u16::MAX as u32 - 4) {
-            let _ = gen.next_id();
+            let _ = id_gen.next_id();
         }
 
-        assert_eq!(gen.next_id(), 0xFFFE);
-        assert_eq!(gen.next_id(), 0xFFFF); // last value of u16 type
+        assert_eq!(id_gen.next_id(), 0xFFFE);
+        assert_eq!(id_gen.next_id(), 0xFFFF); // last value of u16 type
 
         // Expect counter overflow and correcting action of the value after overflow
         // The next value after 0xFFFF should be 1 (the value of message id == 0 should be skipped)
-        assert_eq!(gen.next_id(), 1);
-        assert_eq!(gen.next_id(), 2);
+        assert_eq!(id_gen.next_id(), 1);
+        assert_eq!(id_gen.next_id(), 2);
     }
 }

--- a/ieee1905-core/src/cmdu_observer.rs
+++ b/ieee1905-core/src/cmdu_observer.rs
@@ -17,14 +17,14 @@
  * limitations under the License.
 */
 
-use crate::cmdu::{CMDUType, CMDU};
+use crate::cmdu::{CMDU, CMDUType};
 use crate::cmdu_handler::CMDUHandler;
 use crate::ethernet_subject_reception::EthernetFrameObserver;
 use crate::next_task_id;
 use async_trait::async_trait;
 use pnet::datalink::MacAddr;
 use std::sync::Arc;
-use tracing::{error, info_span, trace, warn, Instrument};
+use tracing::{Instrument, error, info_span, trace, warn};
 
 #[derive(Clone)]
 pub struct CMDUObserver {
@@ -63,8 +63,8 @@ impl EthernetFrameObserver for CMDUObserver {
 
                 trace!("Processing CMDU type: {cmdu_type:?}");
                 let handler = Arc::clone(&self.handler); // Explicit type annotation
-                                                         //TODO to clean up
-                                                         //let interface_name = handler_ref.interface_name.clone(); // --> not needed for now unles we pass the interface to the handler
+                //TODO to clean up
+                //let interface_name = handler_ref.interface_name.clone(); // --> not needed for now unles we pass the interface to the handler
 
                 tokio::task::spawn(
                     async move {

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -16,6 +16,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+use crate::SDU;
 use crate::al_sap::AlServiceAccessPoint;
 use crate::cmdu::TLV;
 use crate::cmdu_codec::*;
@@ -23,14 +24,13 @@ use crate::ethernet_subject_transmission::EthernetSender;
 use crate::interface_manager::get_mac_address_by_interface;
 use crate::tlv_cmdu_codec::TLVTrait;
 use crate::topology_manager::{Ieee1905Node, Role, TopologyDatabase, UpdateType};
-use crate::SDU;
-use crate::{next_task_id, MessageIdGenerator};
+use crate::{MessageIdGenerator, next_task_id};
 use pnet::datalink::MacAddr;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::time::{interval, Duration};
+use tokio::time::{Duration, interval};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, info_span, instrument, trace, warn, Instrument};
+use tracing::{Instrument, debug, error, info, info_span, instrument, trace, warn};
 
 #[instrument(skip_all, name = "cmdu_discovery_transmission", fields(task = next_task_id()))]
 pub async fn cmdu_topology_discovery_transmission_worker(
@@ -856,8 +856,10 @@ mod tests {
         let db = TopologyDatabase::new(MacAddr::broadcast(), "if_name".to_string());
         *db.local_interface_list.write().await = Some(vec![if1.clone(), if2.clone()]);
 
-        let mut device = Ieee1905DeviceData::default();
-        device.al_mac = MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x01, 0x01);
+        let device = Ieee1905DeviceData {
+            al_mac: MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x01, 0x01),
+            ..Default::default()
+        };
         db.update_ieee1905_topology(
             device.clone(),
             UpdateType::DiscoveryReceived,

--- a/ieee1905-core/src/cmdu_reassembler.rs
+++ b/ieee1905-core/src/cmdu_reassembler.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 use tokio::time::Duration;
-use tracing::{info_span, Instrument};
+use tracing::{Instrument, info_span};
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum CmduReassemblyError {
@@ -150,8 +150,8 @@ impl CmduReassembler {
 pub mod tests {
     use super::*;
     use crate::cmdu::TLV;
-    use crate::cmdu_codec::tests::make_dummy_cmdu;
     use crate::cmdu_codec::MessageVersion;
+    use crate::cmdu_codec::tests::make_dummy_cmdu;
     use tokio::time::sleep;
     use tracing::{error, trace};
 
@@ -298,7 +298,7 @@ pub mod tests {
         cmdu2.flags = 0x80; // set last fragment flag
 
         let source_mac = MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66);
-        let fragments = vec![cmdu0, cmdu1, cmdu2];
+        let fragments = [cmdu0, cmdu1, cmdu2];
         let cmdu_reasm = CmduReassembler::new();
 
         for fragment in fragments.iter() {

--- a/ieee1905-core/src/ethernet_subject_reception.rs
+++ b/ieee1905-core/src/ethernet_subject_reception.rs
@@ -24,16 +24,16 @@ use crate::next_task_id;
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use pnet::datalink::{self, Channel::Ethernet, Config};
-use pnet::packet::ethernet::EthernetPacket;
 use pnet::packet::Packet;
+use pnet::packet::ethernet::EthernetPacket;
 use pnet::util::MacAddr;
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::io::ErrorKind;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
-use tokio::task::{yield_now, JoinSet};
-use tracing::{debug, error, info, info_span, warn, Instrument};
+use tokio::task::{JoinSet, yield_now};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 
 /// Observer trait for handling specific Ethernet frame types
 #[async_trait]
@@ -80,7 +80,9 @@ impl EthernetReceiver {
         // Si ya hay un canal para ese ethertype, no duplicamos suscripciones
         let observer_entry = match self.observers.entry(ether_type) {
             Entry::Occupied(_) => {
-                warn!("Observer for EtherType 0x{ether_type:04X} is already subscribed — skipping duplicate");
+                warn!(
+                    "Observer for EtherType 0x{ether_type:04X} is already subscribed — skipping duplicate"
+                );
                 return;
             }
             Entry::Vacant(e) => e,
@@ -167,7 +169,7 @@ impl EthernetReceiver {
                     Ok(e) => {
                         retry_timeout = Self::RETRY_TIMEOUT_MIN;
                         e
-                    },
+                    }
                     Err(e) => {
                         if e.kind() != ErrorKind::TimedOut {
                             error!("Error receiving Ethernet frame: {e}");

--- a/ieee1905-core/src/ethernet_subject_transmission.rs
+++ b/ieee1905-core/src/ethernet_subject_transmission.rs
@@ -20,9 +20,9 @@ use crate::next_task_id;
 use anyhow::anyhow;
 use pnet::datalink::MacAddr;
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinSet;
-use tracing::{debug, error, info, info_span, warn, Instrument};
+use tracing::{Instrument, debug, error, info, info_span, warn};
 
 #[derive(Debug)]
 struct Frame {

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -25,14 +25,14 @@ use pnet::datalink::{self, MacAddr};
 // Standard library
 use crate::cmdu_codec::{MediaType, MediaTypeSpecialInfo, MediaTypeSpecialInfoWifi};
 use crate::linux::eth_tool::{
-    EthToolBitsetAttr, EthToolBitsetBitAttr, EthToolHeaderAttribute, EthToolLinkMode,
-    EthToolLinkModesAttribute, EthToolMessage, ETH_TOOL_GENL_NAME,
+    ETH_TOOL_GENL_NAME, EthToolBitsetAttr, EthToolBitsetBitAttr, EthToolHeaderAttribute,
+    EthToolLinkMode, EthToolLinkModesAttribute, EthToolMessage,
 };
 use crate::linux::if_link::{RtnlLinkStats, RtnlLinkStats64};
 use crate::linux::nl80211::{
-    Nl80211Attribute, Nl80211Band, Nl80211BandAttr, Nl80211BandIfTypeAttr, Nl80211BitrateAttr,
-    Nl80211ChannelWidth, Nl80211Command, Nl80211IfType, Nl80211RateInfo, Nl80211StaInfo,
-    Nl80211SurveyInfoAttr, NL80211_GENL_NAME,
+    NL80211_GENL_NAME, Nl80211Attribute, Nl80211Band, Nl80211BandAttr, Nl80211BandIfTypeAttr,
+    Nl80211BitrateAttr, Nl80211ChannelWidth, Nl80211Command, Nl80211IfType, Nl80211RateInfo,
+    Nl80211StaInfo, Nl80211SurveyInfoAttr,
 };
 use crate::topology_manager::{Ieee1905InterfaceData, Ieee1905LocalInterface};
 use indexmap::{IndexMap, IndexSet};
@@ -744,10 +744,10 @@ async fn call_eth_tool_get_link_modes(
             if let Ok(bits) = bitset_handle.get_nested_attributes::<u16>(EthToolBitsetAttr::Bits) {
                 for bit in bits.iter() {
                     let bit = bit.get_attr_handle::<EthToolBitsetBitAttr>()?;
-                    if let Ok(index) = bit.get_attr_payload_as(EthToolBitsetBitAttr::Index) {
-                        if flags_802_3ab.contains(&index) {
-                            is_802_3ab_supported = true;
-                        }
+                    if let Ok(index) = bit.get_attr_payload_as(EthToolBitsetBitAttr::Index)
+                        && flags_802_3ab.contains(&index)
+                    {
+                        is_802_3ab_supported = true;
                     }
                 }
             }

--- a/ieee1905-core/src/lib.rs
+++ b/ieee1905-core/src/lib.rs
@@ -45,16 +45,16 @@ pub mod rbus;
 
 // ───── Submodules: TLVs grouped under namespaces ─────
 pub mod lldpdu {
-    pub use crate::lldpdu_codec::{ChassisId, LLDPTLVType, PortId, TimeToLiveTLV, LLDPDU};
+    pub use crate::lldpdu_codec::{ChassisId, LLDPDU, LLDPTLVType, PortId, TimeToLiveTLV};
     pub use crate::tlv_lldpdu_codec::TLV;
 }
 
 pub mod cmdu {
     pub use crate::cmdu_codec::{
-        AlMacAddress, BridgingTuple, CMDUType, DeviceBridgingCapability, DeviceInformation,
+        AlMacAddress, BridgingTuple, CMDU, CMDUType, DeviceBridgingCapability, DeviceInformation,
         IEEE1905Neighbor, IEEE1905TLVType, Ieee1905NeighborDevice, LocalInterface, MacAddress,
         NonIEEE1905LocalInterfaceNeighborhood, NonIEEE1905Neighbor, NonIeee1905NeighborDevices,
-        VendorSpecificInfo, CMDU,
+        VendorSpecificInfo,
     };
     pub use crate::tlv_cmdu_codec::TLV;
 }

--- a/ieee1905-core/src/linux.rs
+++ b/ieee1905-core/src/linux.rs
@@ -1,3 +1,3 @@
+pub mod eth_tool;
 pub mod if_link;
 pub mod nl80211;
-pub mod eth_tool;

--- a/ieee1905-core/src/lldpdu_codec.rs
+++ b/ieee1905-core/src/lldpdu_codec.rs
@@ -20,10 +20,10 @@
 #![deny(warnings)]
 // External crates
 use nom::{
+    Err as NomErr, IResult,
     bytes::complete::take,
     error::ErrorKind,
-    number::complete::{be_u16, be_u8},
-    Err as NomErr, IResult,
+    number::complete::{be_u8, be_u16},
 };
 use pnet::datalink::MacAddr;
 

--- a/ieee1905-core/src/lldpdu_observer.rs
+++ b/ieee1905-core/src/lldpdu_observer.rs
@@ -26,7 +26,7 @@ use tracing::{debug, error, info, warn};
 
 // Internal modules
 use crate::ethernet_subject_reception::EthernetFrameObserver;
-use crate::lldpdu::{ChassisId, LLDPTLVType, PortId, LLDPDU};
+use crate::lldpdu::{ChassisId, LLDPDU, LLDPTLVType, PortId};
 use crate::topology_manager::{TopologyDatabase, UpdateType};
 
 #[derive(Clone)]
@@ -159,7 +159,8 @@ impl EthernetFrameObserver for LLDPObserver {
                     // Log when a loop is detected
                     return tracing::trace!(
                         "Loop detected: neighbor_chassis_id ({:?}) is equal to local_chassis_id ({:?})",
-                        neighbor_chassis_id, self.local_chassis_id
+                        neighbor_chassis_id,
+                        self.local_chassis_id
                     );
                 }
 

--- a/ieee1905-core/src/lldpdu_proxy.rs
+++ b/ieee1905-core/src/lldpdu_proxy.rs
@@ -18,10 +18,10 @@
 */
 
 use crate::ethernet_subject_transmission::EthernetSender;
-use crate::lldpdu::{ChassisId, LLDPTLVType, PortId, TimeToLiveTLV, LLDPDU, TLV};
+use crate::lldpdu::{ChassisId, LLDPDU, LLDPTLVType, PortId, TLV, TimeToLiveTLV};
 use crate::next_task_id;
 use pnet::datalink::MacAddr;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tracing::{debug, error, info, instrument};
 
 /// Launches the discovery process for L2 devices using LLDP.

--- a/ieee1905-core/src/logger.rs
+++ b/ieee1905-core/src/logger.rs
@@ -1,13 +1,13 @@
 mod rolling_file_appender;
 
-use crate::logger::rolling_file_appender::RollingFileAppender;
 use crate::CliArgs;
+use crate::logger::rolling_file_appender::RollingFileAppender;
 use std::num::NonZeroUsize;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::EnvFilter;
 
 ///////////////////////////////////////////////////////////////////////////
 const BYTES_IN_MB: NonZeroUsize = NonZeroUsize::new(1024 * 1024).unwrap();
@@ -48,12 +48,18 @@ pub fn init_logger(cli: &CliArgs) -> Option<WorkerGuard> {
     #[cfg(feature = "enable_tokio_console")]
     if cli.console_subscriber {
         use tracing_subscriber::Layer;
-        
+
+        let console_layer = console_subscriber::ConsoleLayer::builder()
+            .with_default_env()
+            .server_addr(std::net::SocketAddr::from(([0, 0, 0, 0], 6669)))
+            .spawn();
+
         tracing::info!("Tokio console: Enabled");
         tracing_subscriber::registry()
             .with(logging_layer.with_filter(filter))
-            .with(console_subscriber::spawn())
+            .with(console_layer)
             .init();
+
         return file_layer_guard;
     }
 

--- a/ieee1905-core/src/logger/rolling_file_appender.rs
+++ b/ieee1905-core/src/logger/rolling_file_appender.rs
@@ -124,10 +124,10 @@ impl RollingFileAppender {
 
     fn get_current_writer(&mut self) -> std::io::Result<&mut CurrentFile> {
         let now = Local::now();
-        if let Some(file) = self.current_file.take() {
-            if !self.should_rollover(&file, &now) {
-                return Ok(self.current_file.insert(file));
-            }
+        if let Some(file) = self.current_file.take()
+            && !self.should_rollover(&file, &now)
+        {
+            return Ok(self.current_file.insert(file));
         }
 
         std::fs::create_dir_all(&self.folder)?;

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -32,16 +32,16 @@ use ieee1905::interface_manager::*;
 use ieee1905::lldpdu_observer::LLDPObserver;
 use ieee1905::lldpdu_proxy::lldp_discovery_worker;
 use ieee1905::topology_manager::*;
-use ieee1905::{next_task_id, CMDUObserver};
+use ieee1905::{CMDUObserver, next_task_id};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 //use ieee1905::crypto_engine::CRYPTO_CONTEXT;
 use anyhow::anyhow;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::signal::unix::{signal, SignalKind};
-use tokio::sync::oneshot;
+use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::Mutex;
+use tokio::sync::oneshot;
 use tracing::instrument;
 
 use sd_notify::NotifyState;
@@ -87,9 +87,6 @@ struct CliArgs {
 
 fn main() -> anyhow::Result<()> {
     let cli = CliArgs::parse();
-
-    // Start the Tokio console subscriber
-    std::env::set_var("RUST_CONSOLE_BIND", "0.0.0.0:6669");
 
     let _guard = logger::init_logger(&cli);
     tracing::info!("Tracing initialized!");

--- a/ieee1905-core/src/rbus.rs
+++ b/ieee1905-core/src/rbus.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types)]
 
+use crate::TopologyDatabase;
 use crate::cmdu_codec::MediaType;
 use crate::rbus::al_device::RBus_Al_Device;
 use crate::rbus::interface::RBus_Interface;
@@ -10,14 +11,13 @@ use crate::rbus::nt_device::RBus_NetworkTopology_Ieee1905Device;
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
 use crate::rbus::nt_device_bridge_list::RBus_NetworkTopology_Ieee1905Device_BridgingTuple_InterfaceList;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
-use crate::TopologyDatabase;
 use anyhow::bail;
 use pnet::datalink::MacAddr;
 use rbus_core::{RBusError, RBusLibrary, RBusLogHandler, RBusLogLevel, RBusLogRecord};
+use rbus_provider::element::RBusProviderElement;
 use rbus_provider::element::object::rbus_object;
 use rbus_provider::element::property::rbus_property;
 use rbus_provider::element::table::rbus_table;
-use rbus_provider::element::RBusProviderElement;
 use rbus_provider::provider::{RBusProvider, RBusProviderError};
 use std::sync::Arc;
 use tracing::{debug, error, info, instrument, warn};

--- a/ieee1905-core/src/rbus/interface.rs
+++ b/ieee1905-core/src/rbus/interface.rs
@@ -27,7 +27,7 @@ impl RBusProviderGetter for RBus_Interface {
     type UserData = ();
 
     fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
-        let Some(if_index) = args.table_idx.get(0) else {
+        let Some(if_index) = args.table_idx.first() else {
             return Err(RBusError::ElementDoesNotExists);
         };
 

--- a/ieee1905-core/src/rbus/interface_link.rs
+++ b/ieee1905-core/src/rbus/interface_link.rs
@@ -1,8 +1,8 @@
+use crate::TopologyDatabase;
 use crate::rbus::{format_mac_address, format_media_type, peek_topology_database};
 use crate::topology_manager::{
     Ieee1905DeviceData, Ieee1905InterfaceData, Ieee1905LocalInterface, Ieee1905NodeInternal,
 };
-use crate::TopologyDatabase;
 use nom::AsBytes;
 use rbus_core::RBusError;
 use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
@@ -21,7 +21,7 @@ impl RBus_InterfaceLink {
         db: &TopologyDatabase,
         table_idx: &[u32],
     ) -> Result<(Ieee1905LocalInterface, Vec<Ieee1905DeviceData>), RBusError> {
-        let Some(if_index) = table_idx.get(0) else {
+        let Some(if_index) = table_idx.first() else {
             return Err(RBusError::ElementDoesNotExists);
         };
 
@@ -58,7 +58,7 @@ impl RBusProviderTableSync for RBus_InterfaceLink {
 
     fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
         let db = peek_topology_database()?;
-        let (_, links) = Self::get_links(&db, args.table_idx)?;
+        let (_, links) = Self::get_links(db, args.table_idx)?;
         Ok(links.len() as u32)
     }
 }
@@ -72,7 +72,7 @@ impl RBusProviderGetter for RBus_InterfaceLink {
         };
 
         let db = peek_topology_database()?;
-        let (_, links) = Self::get_links(&db, args.table_idx)?;
+        let (_, links) = Self::get_links(db, args.table_idx)?;
         let Some(link) = links.get(*link_index as usize) else {
             return Err(RBusError::ElementDoesNotExists);
         };

--- a/ieee1905-core/src/rbus/interface_link_metric.rs
+++ b/ieee1905-core/src/rbus/interface_link_metric.rs
@@ -27,7 +27,7 @@ impl RBusProviderGetter for RBus_InterfaceLinkMetric {
         };
 
         let db = peek_topology_database()?;
-        let (interface, links) = RBus_InterfaceLink::get_links(&db, args.table_idx)?;
+        let (interface, links) = RBus_InterfaceLink::get_links(db, args.table_idx)?;
         let Some(_) = links.get(*link_index as usize) else {
             return Err(RBusError::ElementDoesNotExists);
         };

--- a/ieee1905-core/src/rbus/nt.rs
+++ b/ieee1905-core/src/rbus/nt.rs
@@ -18,7 +18,7 @@ impl RBusProviderGetter for RBus_NetworkTopology {
 
         match args.path_name.as_bytes() {
             b"IEEE1905DeviceNumberOfEntries" => {
-                let len = RBus_NetworkTopology_Ieee1905Device::count_rows(&db);
+                let len = RBus_NetworkTopology_Ieee1905Device::count_rows(db);
                 args.property.set(&(len as u32));
                 Ok(())
             }

--- a/ieee1905-core/src/rbus/nt_device.rs
+++ b/ieee1905-core/src/rbus/nt_device.rs
@@ -1,3 +1,4 @@
+use crate::TopologyDatabase;
 use crate::cmdu_codec::{DeviceIdentificationType, Ieee1905ProfileVersion, SupportedFreqBand};
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
@@ -5,7 +6,6 @@ use crate::rbus::{format_mac_address, peek_topology_database};
 use crate::topology_manager::{
     Ieee1905InterfaceData, Ieee1905LocalInterface, Ieee1905NodeInternal,
 };
-use crate::TopologyDatabase;
 use either::Either;
 use nom::AsBytes;
 use rbus_core::RBusError;
@@ -40,7 +40,7 @@ impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device {
     fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
         let _ = args;
         let db = peek_topology_database()?;
-        Ok(Self::count_rows(&db) as u32)
+        Ok(Self::count_rows(db) as u32)
     }
 }
 
@@ -49,7 +49,7 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
 
     fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
         let db = peek_topology_database()?;
-        let node = RBus_Ieee1905Device_Node::from(&db, args.table_idx)?.1;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
 
         match args.path_name.as_bytes() {
             b"IEEE1905Id" => {
@@ -135,19 +135,19 @@ pub enum RBus_Ieee1905Device_Node<'a> {
 
 impl<'a> RBus_Ieee1905Device_Node<'a> {
     pub fn from(db: &'a TopologyDatabase, table_idx: &[u32]) -> Result<(u32, Self), RBusError> {
-        let Some(node_index) = table_idx.get(0).copied() else {
+        let Some(node_index) = table_idx.first() else {
             return Err(RBusError::ElementDoesNotExists);
         };
 
         let Some(index) = node_index.checked_sub(1) else {
             let ifs = db.local_interface_list.blocking_read();
             let ifs = RwLockReadGuard::map(ifs, |e| e.as_deref().unwrap_or_default());
-            return Ok((node_index, Self::Local(ifs)));
+            return Ok((*node_index, Self::Local(ifs)));
         };
 
         let nodes = db.nodes.blocking_read();
         match RwLockReadGuard::try_map(nodes, |e| Some(e.get_index(index as usize)?.1)) {
-            Ok(e) => Ok((node_index, Self::Remote(e))),
+            Ok(e) => Ok((*node_index, Self::Remote(e))),
             Err(_) => Err(RBusError::ElementDoesNotExists),
         }
     }

--- a/ieee1905-core/src/rbus/nt_device_bridge.rs
+++ b/ieee1905-core/src/rbus/nt_device_bridge.rs
@@ -28,7 +28,7 @@ impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device_BridgingTuple
 
     fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
         let db = peek_topology_database()?;
-        let node = RBus_Ieee1905Device_Node::from(&db, args.table_idx)?.1;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
         let tuples = Self::get_tuples(&node);
         Ok(tuples.len() as u32)
     }

--- a/ieee1905-core/src/rbus/nt_device_bridge_list.rs
+++ b/ieee1905-core/src/rbus/nt_device_bridge_list.rs
@@ -18,7 +18,7 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_BridgingTuple_In
         };
 
         let db = peek_topology_database()?;
-        let (node_index, node) = RBus_Ieee1905Device_Node::from(&db, args.table_idx)?;
+        let (node_index, node) = RBus_Ieee1905Device_Node::from(db, args.table_idx)?;
         let tuples = RBus_NetworkTopology_Ieee1905Device_BridgingTuple::get_tuples(&node);
 
         let Some((_, interfaces)) = tuples.get_index(tuple_index as usize) else {

--- a/ieee1905-core/src/rbus/nt_device_non_ieee1905_neighbor.rs
+++ b/ieee1905-core/src/rbus/nt_device_non_ieee1905_neighbor.rs
@@ -47,10 +47,10 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neigh
         };
 
         let db = peek_topology_database()?;
-        let (node_index, node) = RBus_Ieee1905Device_Node::from(&db, args.table_idx)?;
-        let neighbours = Self::iter_neighbors(&node);
+        let (node_index, node) = RBus_Ieee1905Device_Node::from(db, args.table_idx)?;
+        let mut neighbours = Self::iter_neighbors(&node);
 
-        let Some((if_index, neighbour)) = neighbours.skip(neighbour_index as usize).next() else {
+        let Some((if_index, neighbour)) = neighbours.nth(neighbour_index as usize) else {
             return Err(RBusError::ElementDoesNotExists);
         };
 

--- a/ieee1905-core/src/registration_codec.rs
+++ b/ieee1905-core/src/registration_codec.rs
@@ -20,10 +20,10 @@
 #![deny(warnings)]
 // External crates
 use nom::{
+    Err as NomErr, IResult,
     bytes::complete::take,
     error::ErrorKind,
-    number::complete::{be_u16, be_u8},
-    Err as NomErr, IResult,
+    number::complete::{be_u8, be_u16},
 };
 use pnet::datalink::MacAddr;
 
@@ -43,7 +43,7 @@ impl ServiceOperation {
                 return Err(nom::Err::Failure(nom::error::Error::new(
                     input,
                     nom::error::ErrorKind::Tag,
-                )))
+                )));
             }
         };
         Ok((input, op))
@@ -70,7 +70,7 @@ impl ServiceType {
                 return Err(nom::Err::Failure(nom::error::Error::new(
                     input,
                     nom::error::ErrorKind::Tag,
-                )))
+                )));
             }
         };
         Ok((input, st))
@@ -101,7 +101,7 @@ impl RegistrationResult {
                 return Err(nom::Err::Failure(nom::error::Error::new(
                     input,
                     nom::error::ErrorKind::Tag,
-                )))
+                )));
             }
         };
         Ok((input, result))

--- a/ieee1905-core/src/sdu_codec.rs
+++ b/ieee1905-core/src/sdu_codec.rs
@@ -19,7 +19,7 @@
 
 #![deny(warnings)]
 // External crates
-use nom::{bytes::complete::take, multi::many0, number::complete::be_u8, IResult, Parser};
+use nom::{IResult, Parser, bytes::complete::take, multi::many0, number::complete::be_u8};
 use pnet::datalink::MacAddr;
 
 // Standard library
@@ -163,10 +163,10 @@ impl SDU {
 mod tests {
     use super::*;
     use crate::cmdu_codec::IEEE1905TLVType;
-    use crate::cmdu_codec::{CMDUType, CMDU};
+    use crate::cmdu_codec::{CMDU, CMDUType};
     use crate::tlv_cmdu_codec::TLV;
-    use nom::error::ErrorKind;
     use nom::Err as NomErr;
+    use nom::error::ErrorKind;
     use pnet::datalink::MacAddr;
 
     // Verify parsing and serializing of SDU and CMDU
@@ -619,7 +619,9 @@ mod tests {
         match SDU::parse(&sdu_bytes) {
             Ok(_) => { /* everything after EOM is considered padding */ }
             Err(NomErr::Error(_)) | Err(NomErr::Incomplete(_)) => {
-                panic!("ErrorKind::Tag should be returned on additional TLV after EndOfMessage TLV in CMDU");
+                panic!(
+                    "ErrorKind::Tag should be returned on additional TLV after EndOfMessage TLV in CMDU"
+                );
             }
             Err(NomErr::Failure(e)) => {
                 assert_eq!(e.code, nom::error::ErrorKind::Tag);

--- a/ieee1905-core/src/tlv_cmdu_codec.rs
+++ b/ieee1905-core/src/tlv_cmdu_codec.rs
@@ -21,10 +21,10 @@
 // External crates
 use nom::Err as NomErr;
 use nom::{
-    bytes::complete::take, // Parses a specified number of bytes from the input.
-    error::ErrorKind,      // Represents specific parsing error types.
-    number::complete::{be_u16, be_u8}, // Parses unsigned integers in big-endian format.
     IResult, // Represents the result of a parsing operation, either success or failure.
+    bytes::complete::take, // Parses a specified number of bytes from the input.
+    error::ErrorKind, // Represents specific parsing error types.
+    number::complete::{be_u8, be_u16}, // Parses unsigned integers in big-endian format.
 }; // Alias for errors returned by `nom` parsers.
 
 // Standard library
@@ -250,7 +250,9 @@ mod tests {
                 assert_eq!(e.code, ErrorKind::LengthValue);
             }
             Err(nom::Err::Incomplete(_)) | Err(nom::Err::Error(_)) => {
-                panic!("Expected parsing to fail with LengthValue error, but it failed with a different error.");
+                panic!(
+                    "Expected parsing to fail with LengthValue error, but it failed with a different error."
+                );
             }
         }
     }

--- a/ieee1905-core/src/tlv_lldpdu_codec.rs
+++ b/ieee1905-core/src/tlv_lldpdu_codec.rs
@@ -21,10 +21,10 @@
 // External crates
 use nom::Err as NomErr;
 use nom::{
-    bytes::complete::take,    // Parses a specified number of bytes from the input.
-    error::ErrorKind,         // Represents specific parsing error types.
-    number::complete::be_u16, // Parses unsigned integers in big-endian format.
     IResult, // Represents the result of a parsing operation, either success or failure.
+    bytes::complete::take, // Parses a specified number of bytes from the input.
+    error::ErrorKind, // Represents specific parsing error types.
+    number::complete::be_u16, // Parses unsigned integers in big-endian format.
 }; // Alias for errors returned by `nom` parsers.
 
 // Standard library
@@ -187,6 +187,6 @@ mod tests {
         assert!(result.is_ok());
 
         // Expect that parser returns redundant (not needed) data: &['G', 'H']
-        assert_eq!(result.unwrap().0, &[b'G', b'H']);
+        assert_eq!(result.unwrap().0, b"GH");
     }
 }

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -23,20 +23,20 @@
 use crossterm::{
     event::{self, KeyCode},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use pnet::datalink::MacAddr;
 use ratatui::{
+    Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Row, Table},
-    Terminal,
 };
 use tokio::{
     sync::RwLock,
     task::yield_now,
-    time::{interval, Duration, Instant},
+    time::{Duration, Instant, interval},
 };
 use tracing::{debug, error, info, instrument};
 // Standard library
@@ -256,24 +256,24 @@ impl Ieee1905NodeInfo {
             self.lldp_neighbor = Some(lldp_neighbor);
         }
 
-        if let Some(local) = new_node_state_local {
-            if self.node_state_local != local {
-                info!(
-                    "{} local state changed: {:?} -> {local:?}",
-                    self.al_mac, self.node_state_local
-                );
-                self.node_state_local = local;
-            }
+        if let Some(local) = new_node_state_local
+            && self.node_state_local != local
+        {
+            info!(
+                "{} local state changed: {:?} -> {local:?}",
+                self.al_mac, self.node_state_local,
+            );
+            self.node_state_local = local;
         }
 
-        if let Some(remote) = new_node_state_remote {
-            if self.node_state_remote != remote {
-                info!(
-                    "{} remote state changed: {:?} -> {remote:?}",
-                    self.al_mac, self.node_state_remote
-                );
-                self.node_state_remote = remote;
-            }
+        if let Some(remote) = new_node_state_remote
+            && self.node_state_remote != remote
+        {
+            info!(
+                "{} remote state changed: {:?} -> {remote:?}",
+                self.al_mac, self.node_state_remote,
+            );
+            self.node_state_remote = remote;
         }
 
         self.last_seen = Instant::now();
@@ -588,27 +588,27 @@ impl TopologyDatabase {
 
             nodes.retain(|al_mac, node| {
                 // Remove nodes stuck in ConvergingLocal state
-                if let StateLocal::ConvergingLocal(when) = node.metadata.node_state_local {
-                    if now.duration_since(when) >= Duration::from_secs(5) {
-                        debug!(
-                            al_mac = ?al_mac,
-                            state = ?node.metadata.last_update,
-                            "Removing node stuck in local convergence for too long"
-                        );
-                        return false; // Remove from database
-                    }
+                if let StateLocal::ConvergingLocal(when) = node.metadata.node_state_local
+                    && now.duration_since(when) >= Duration::from_secs(5)
+                {
+                    debug!(
+                        al_mac = ?al_mac,
+                        state = ?node.metadata.last_update,
+                        "Removing node stuck in local convergence for too long"
+                    );
+                    return false; // Remove from database
                 }
 
                 // Remove nodes stuck in ConvergingRemote state
-                if let StateRemote::ConvergingRemote(when) = node.metadata.node_state_remote {
-                    if now.duration_since(when) >= Duration::from_secs(5) {
-                        debug!(
-                            al_mac = ?al_mac,
-                            state = ?node.metadata.last_update,
-                            "Removing node stuck in remote convergence for too long"
-                        );
-                        return false; // Remove from database
-                    }
+                if let StateRemote::ConvergingRemote(when) = node.metadata.node_state_remote
+                    && now.duration_since(when) >= Duration::from_secs(5)
+                {
+                    debug!(
+                        al_mac = ?al_mac,
+                        state = ?node.metadata.last_update,
+                        "Removing node stuck in remote convergence for too long"
+                    );
+                    return false; // Remove from database
                 }
 
                 // Remove nodes that have been inactive
@@ -1008,10 +1008,7 @@ impl TopologyDatabase {
 
                 let top_chunks = Layout::default()
                     .direction(Direction::Horizontal)
-                    .constraints([
-                        Constraint::Percentage(70),
-                        Constraint::Percentage(30),
-                    ])
+                    .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
                     .split(chunks[0]);
 
                 // ─────────────────────── BLOQUE 1: TOPOLOGY MANAGER
@@ -1142,13 +1139,14 @@ impl TopologyDatabase {
 
                 f.render_widget(paragraph3, chunks[2]);
             })?;
+
             yield_now().await;
-            if event::poll(Duration::from_millis(500))? {
-                if let event::Event::Key(key) = event::read()? {
-                    if key.code == KeyCode::Char('q') {
-                        break;
-                    }
-                }
+
+            if event::poll(Duration::from_millis(500))?
+                && let event::Event::Key(key) = event::read()?
+                && key.code == KeyCode::Char('q')
+            {
+                break;
             }
         }
 
@@ -1160,9 +1158,9 @@ impl TopologyDatabase {
 
 #[cfg(test)]
 mod tests {
+    use crate::TopologyDatabase;
     use crate::cmdu_codec::MediaType;
     use crate::topology_manager::{Ieee1905DeviceData, Ieee1905InterfaceData, UpdateType};
-    use crate::TopologyDatabase;
     use pnet::datalink::MacAddr;
 
     #[tokio::test]
@@ -1191,7 +1189,7 @@ mod tests {
             device_al_mac,
             device_al_mac,
             Some(device_mac),
-            db.local_mac.read().await.clone(),
+            *db.local_mac.read().await,
             Some(vec![interface]),
             None,
         );
@@ -1206,9 +1204,10 @@ mod tests {
 
         assert!(db.find_device_by_port(device_mac).await.is_some());
         assert!(db.find_device_by_port(device_al_mac).await.is_some());
-        assert!(db
-            .find_device_by_port(MacAddr::new(0, 0, 0, 0, 0, 4))
-            .await
-            .is_none());
+        assert!(
+            db.find_device_by_port(MacAddr::new(0, 0, 0, 0, 0, 4))
+                .await
+                .is_none()
+        );
     }
 }

--- a/ieee1905-tests/Cargo.toml
+++ b/ieee1905-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ieee1905-tests"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 publish = false
 license = "Apache-2.0"
 

--- a/ieee1905-tests/src/functional_tests_receiver.rs
+++ b/ieee1905-tests/src/functional_tests_receiver.rs
@@ -26,7 +26,7 @@ use ieee1905::sdu_codec::SDU;
 use std::process::exit;
 use tokio::net::UnixStream;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 // Send response to transmitter containing complete SDU: (SDU + CMDU + TLVs)
 // Only the TLV chain is a 1-to-1 copy without any modifications as SDU and CMDU headers

--- a/ieee1905-tests/src/functional_tests_transmitter.rs
+++ b/ieee1905-tests/src/functional_tests_transmitter.rs
@@ -28,9 +28,9 @@ use ieee1905::sdu_codec::SDU;
 use pnet::datalink::*;
 use std::process::exit;
 use tokio::net::UnixStream;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 fn _prepare_test_packet_with_payload(
     r: &AlServiceRegistrationResponse,
@@ -2077,15 +2077,15 @@ async fn read_data(
                                 }
 
                                 assembled_payload.extend(&fragment.payload);
-                                if fragment.is_last_fragment == 1 {
-                                    if let Some(mut final_message) = message.clone() {
-                                        final_message.payload = assembled_payload.clone();
-                                        tracing::info!(
-                                            "Got reassembled SDU [{:?}] {final_message:?}",
-                                            final_message.payload.len()
-                                        );
-                                        return Ok(final_message);
-                                    }
+                                if fragment.is_last_fragment == 1
+                                    && let Some(mut final_message) = message.clone()
+                                {
+                                    final_message.payload = assembled_payload.clone();
+                                    tracing::info!(
+                                        "Got reassembled SDU [{:?}] {final_message:?}",
+                                        final_message.payload.len()
+                                    );
+                                    return Ok(final_message);
                                 }
                                 fragment_id_expected += 1;
                             }


### PR DESCRIPTION
Only two issues were found:
- `gen` is a reserved keyword now
  - single occurance, renamed the variable
- `std::env::set_var` is now unsafe (used for `RUST_CONSOLE_BIND`)
  - was not working because there is no such thing as `RUST_CONSOLE_BIND`, it supposed to be `TOKIO_CONSOLE_BIND`
  - changed to directly set address instead (should we if it was not working before???)
- let-if chains are forces by clippy
- slight auto-formatting differences for imports