### PR TITLE
Upgrade reqwest and rustls-webpki to resolve RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1483,6 +1483,7 @@ dependencies = [
  "rbus-core",
  "rbus-provider",
  "reqwest",
+ "rustls-webpki",
  "sd-notify",
  "serde",
  "serde_json",
@@ -1580,7 +1581,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2303,7 +2304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2549,9 +2550,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2623,7 +2624,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2650,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2964,7 +2965,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3724,7 +3725,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/ieee1905-core/Cargo.toml
+++ b/ieee1905-core/Cargo.toml
@@ -40,13 +40,14 @@ either = "1.15.0"
 parking_lot = "0.12.5"
 axum = "0.8.8"
 tower-http = { version = "0.6.8", features = ["trace"] }
-reqwest = { version = "0.13.2", default-features = false, features = ["http2", "stream", "query", "json"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["http2", "stream", "query", "json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 
 # RUSTSEC transitive dependency overrides
 time = ">=0.3.47"
 rand = ">=0.9.3"
+rustls-webpki = ">=0.103.13"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async_tokio"] }


### PR DESCRIPTION
Fixes [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104)  - Reachable panic in certificate revocation list parsing

Upgraded reqwest from 0.13.2 to 0.13.4
Added rustls-webpki = ">=0.103.13" to RUSTSEC transitive dependency overrides