### PR TITLE
Reduce tracing_appender log buffer from 128k to 1024 lines

### DIFF
--- a/ieee1905-core/src/logger.rs
+++ b/ieee1905-core/src/logger.rs
@@ -32,7 +32,9 @@ pub fn init_logger(cli: &CliArgs) -> Option<WorkerGuard> {
             .max_files(cli.file_appender_files_count)
             .max_file_size(cli.file_appender_max_file_size.saturating_mul(BYTES_IN_MB));
 
-        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        let (non_blocking, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
+            .buffered_lines_limit(1024)
+            .finish(file_appender);
         file_layer_guard = Some(guard);
 
         tracing_subscriber::fmt::layer()


### PR DESCRIPTION
`tracing_appender::non_blocking()` uses a default buffer of 128,000 log lines. 
```
pub const DEFAULT_BUFFERED_LINES_LIMIT: usize = 128_000;
```
#### Fix:
Set `buffered_lines_limit(1024)` via `NonBlockingBuilder`.

**Before:**
```
root@Filogic-GW:~# grep -E "VmRSS|VmHWM|RssAnon" /proc/$(pgrep ieee1905)/status
VmHWM:      6756 kB
VmRSS:      6456 kB
RssAnon:            4788 kB
```

**After:**
```
root@Filogic-GW:~# grep -E "VmRSS|VmHWM|RssAnon" /proc/$(pgrep ieee1905)/status
VmHWM:      2556 kB
VmRSS:      2492 kB
RssAnon:             824 kB
```