### PR TITLE
[#369] separated AL_SAP lifecycle from other components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,6 @@ dependencies = [
  "either",
  "futures",
  "indexmap",
- "lazy_static",
  "neli",
  "nom 8.0.0",
  "once_cell",

--- a/ieee1905-core/Cargo.toml
+++ b/ieee1905-core/Cargo.toml
@@ -28,7 +28,6 @@ anyhow = "1.0.100"
 futures = "0.3"
 tokio-util = "0.7.17"
 clap = { version = "4.5.53", features = ["derive"] }
-lazy_static = "1.5.0"
 once_cell = "1.21.3"
 cryptoki = "0.12"
 thiserror = "2.0.16"

--- a/ieee1905-core/src/al_sap.rs
+++ b/ieee1905-core/src/al_sap.rs
@@ -18,6 +18,8 @@
 */
 
 #![deny(warnings)]
+use crate::cmdu::{CMDUType, TLV};
+use crate::cmdu_codec::{CMDU, CMDUFragmentation, IEEE1905TLVType, Profile2ApCapability};
 use crate::cmdu_message_id_generator::get_message_id_generator;
 use crate::cmdu_proxy::{cmdu_from_sdu_transmission, cmdu_topology_notification_transmission};
 use crate::ethernet_subject_transmission::EthernetSender;
@@ -27,37 +29,31 @@ use crate::registration_codec::{
     ServiceOperation, ServiceType,
 };
 use crate::sdu_codec::SDU;
+use crate::tlv_cmdu_codec::TLVTrait;
 use crate::topology_manager::Role;
 use crate::{TopologyDatabase, next_task_id};
 use anyhow::{Context, Result, bail};
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
-use lazy_static::lazy_static;
 use pnet::datalink::MacAddr;
+use sd_notify;
+use sd_notify::NotifyState;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
+use thiserror::Error;
 use tokio::fs;
 use tokio::net::UnixListener;
 use tokio::net::UnixStream;
 use tokio::sync::{Mutex, OwnedMutexGuard};
 use tokio_util::bytes::Bytes;
 use tokio_util::codec::{Framed, LengthDelimitedCodec};
-// Internal modules
-use crate::cmdu_codec::{CMDU, CMDUFragmentation, IEEE1905TLVType, Profile2ApCapability};
-use tokio::sync::oneshot;
-
-use once_cell::sync::Lazy;
-
-use crate::cmdu::{CMDUType, TLV};
-use thiserror::Error;
 use tracing::{debug, info, instrument, warn};
 
-use crate::tlv_cmdu_codec::TLVTrait;
-use sd_notify;
-use sd_notify::NotifyState;
-
-pub static SAP_INSTANCE: Lazy<Mutex<Option<Arc<Mutex<AlServiceAccessPoint>>>>> =
-    Lazy::new(|| Mutex::new(None));
+type FramedUnix = Framed<UnixStream, LengthDelimitedCodec>;
+static SAP_INSTANCE: Mutex<Option<Arc<Mutex<AlServiceAccessPoint>>>> = Mutex::const_new(None);
+static LAZY_WRITER: Mutex<Option<SplitSink<FramedUnix, Bytes>>> = Mutex::const_new(None);
+static LAZY_READER: Mutex<Option<SplitStream<FramedUnix>>> = Mutex::const_new(None);
 
 #[derive(Error, Debug)]
 pub enum AlSapError {
@@ -79,17 +75,6 @@ async fn get_instance_mut() -> Option<Arc<Mutex<AlServiceAccessPoint>>> {
     lock.clone()
 }
 
-// Define type alias for Framed Unix Stream
-type FramedUnix = Framed<UnixStream, LengthDelimitedCodec>;
-
-// Two halves: read one and write one instead of one AlServiceAccessPoint.data_socket
-lazy_static! {
-    pub static ref LAZY_WRITER: Arc<Mutex<Option<SplitSink<FramedUnix, Bytes>>>> =
-        Arc::new(Mutex::new(None));
-    pub static ref LAZY_READER: Arc<Mutex<Option<SplitStream<FramedUnix>>>> =
-        Arc::new(Mutex::new(None));
-}
-
 pub struct AlServiceAccessPoint {
     framed_control_socket: FramedUnix,
     control_socket_path: PathBuf,
@@ -101,16 +86,33 @@ pub struct AlServiceAccessPoint {
 }
 
 impl AlServiceAccessPoint {
-    #[instrument(skip_all, name = "al_sap_init", fields(task = next_task_id()))]
-    pub async fn initialize_and_store(
+    #[instrument(skip_all, name = "al_sap", fields(task = next_task_id()))]
+    pub async fn run(
         control_socket_path: impl AsRef<Path>,
         data_socket_path: impl AsRef<Path>,
         sender: Arc<EthernetSender>,
         interface_name: String,
-        shutdown_tx: oneshot::Sender<()>,
     ) {
-        SAP_INSTANCE.lock().await.take();
+        loop {
+            Self::run_instance(
+                control_socket_path.as_ref(),
+                data_socket_path.as_ref(),
+                sender.clone(),
+                interface_name.clone(),
+            )
+            .await;
 
+            SAP_INSTANCE.lock().await.take();
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+
+    async fn run_instance(
+        control_socket_path: impl AsRef<Path>,
+        data_socket_path: impl AsRef<Path>,
+        sender: Arc<EthernetSender>,
+        interface_name: String,
+    ) {
         let sap = AlServiceAccessPoint::start_server(
             control_socket_path,
             data_socket_path,
@@ -135,7 +137,7 @@ impl AlServiceAccessPoint {
         match result {
             Ok(_) => {
                 tracing::debug!("Received registration request on control unix stream socket");
-                sap_data_request_handler(shutdown_tx).await;
+                sap_data_request_handler().await;
             }
             Err(err) => {
                 tracing::error!("Registration request error: {:?}", err);
@@ -232,7 +234,7 @@ impl AlServiceAccessPoint {
     }
 
     /// Receives a registration request from the socket (from a client)
-    pub async fn service_access_point_registration_request(
+    async fn service_access_point_registration_request(
         &mut self,
     ) -> Result<AlServiceRegistrationRequest> {
         if let Some(result) = self.framed_control_socket.next().await {
@@ -661,7 +663,7 @@ pub async fn service_access_point_data_request() -> Result<SDU, AlSapError> {
 }
 
 // Do the downward forwarding: unix stream socket -> network
-pub async fn sap_data_request_handler(shutdown_tx: oneshot::Sender<()>) {
+async fn sap_data_request_handler() {
     loop {
         match service_access_point_data_request().await {
             Ok(_) => {
@@ -669,7 +671,6 @@ pub async fn sap_data_request_handler(shutdown_tx: oneshot::Sender<()>) {
             }
             Err(AlSapError::SocketClosed) => {
                 tracing::error!("Connection closed. Need to trigger restart!");
-                let _ = shutdown_tx.send(());
                 break;
             }
             Err(e) => {

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -21,7 +21,9 @@
 
 mod logger;
 
+use anyhow::anyhow;
 use clap::Parser;
+use ieee1905::CMDUObserver;
 use ieee1905::al_sap::AlServiceAccessPoint;
 use ieee1905::cmdu_handler::*;
 use ieee1905::cmdu_message_id_generator::get_message_id_generator;
@@ -32,19 +34,12 @@ use ieee1905::interface_manager::*;
 use ieee1905::lldpdu_observer::LLDPObserver;
 use ieee1905::lldpdu_proxy::lldp_discovery_worker;
 use ieee1905::topology_manager::*;
-use ieee1905::{CMDUObserver, next_task_id};
+use sd_notify::NotifyState;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
-//use ieee1905::crypto_engine::CRYPTO_CONTEXT;
-use anyhow::anyhow;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::Mutex;
-use tokio::sync::oneshot;
-use tracing::instrument;
-
-use sd_notify::NotifyState;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -85,7 +80,8 @@ struct CliArgs {
     no_lldp_receivers: bool,
 }
 
-fn main() -> anyhow::Result<()> {
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
     let cli = CliArgs::parse();
 
     let _guard = logger::init_logger(&cli);
@@ -106,28 +102,6 @@ fn main() -> anyhow::Result<()> {
         tracing::error!("failed to open RBus connection: {e}");
     });
 
-    loop {
-        tracing::info!("Starting runtime");
-        let runtime = tokio::runtime::Runtime::new()?;
-
-        tracing::info!("Runtime started");
-        if runtime.block_on(run_main_logic(&cli))? {
-            break;
-        }
-
-        tracing::info!("Releasing runtime");
-        // timeout is used for blocking tasks, which in our case are related to datalink channels.
-        // all such tasks are configured to have a 1-second timeout, so will die at most in 1 second.
-        runtime.shutdown_timeout(Duration::from_secs(2));
-        tracing::info!("Runtime released");
-    }
-
-    tracing::info!("Closing app.");
-    Ok(())
-}
-
-#[instrument(skip_all, name = "main", fields(task = next_task_id()))]
-async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
     let mut join_sets = Vec::new();
 
     //Set AL MAC & test MAC addresses
@@ -148,7 +122,6 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
     // // Initialize Database
 
     let topology_db = TopologyDatabase::get_instance(al_mac, &cli.interface);
-    let _db_workers = topology_db.start_workers();
 
     // Upon every loop restart topology database role can change
     topology_db.set_local_role(None).await;
@@ -188,15 +161,12 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
     let sender_clone = Arc::clone(&sender);
     let forwarding_interface_clone = forwarding_interface.clone();
 
-    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-
     // Launch of AL-SAP as independent task
-    tokio::task::spawn(AlServiceAccessPoint::initialize_and_store(
+    tokio::task::spawn(AlServiceAccessPoint::run(
         sap_control_path,
         sap_data_path,
         sender_clone,
         forwarding_interface_clone,
-        shutdown_tx,
     ));
 
     // Initialization of the CMDU handler
@@ -270,18 +240,12 @@ async fn run_main_logic(cli: &CliArgs) -> anyhow::Result<bool> {
 
     // if topology_cli is running
     // you can close app by pressing q
-    let mut exit_service = true;
-
     tokio::select! {
         _ = signal_terminate.recv() => {let _ = sd_notify::notify(true, &[NotifyState::Stopping]);},
         _ = signal_interrupt.recv() => {let _ = sd_notify::notify(true, &[NotifyState::Stopping]);},
-        _ = shutdown_rx => {
-            tracing::info!("Socket closed. Trying to restart.");
-            exit_service = false;
-        }
         _ = topology_db.start_topology_cli(), if cli.topology_ui => {}
     }
-    Ok(exit_service)
+    Ok(())
 }
 
 async fn get_lldp_compatible_interfaces() -> Vec<Ieee1905LocalInterface> {

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -46,7 +46,6 @@ use std::ops::Deref;
 use std::sync::OnceLock;
 use std::{io, sync::Arc};
 use tokio::sync::{RwLockMappedWriteGuard, RwLockWriteGuard};
-use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 // Internal modules
 use crate::cmdu_codec::{
@@ -448,21 +447,17 @@ impl TopologyDatabase {
         // Get local MAC address from forwarding interface
         let local_mac = get_forwarding_interface_mac(&interface_name);
 
-        Arc::new(Self {
+        let this = Arc::new(Self {
             al_mac_address,
             interface_name,
             local_mac: Arc::new(RwLock::new(local_mac)),
             local_interface_list: Arc::new(RwLock::new(None)),
             nodes: Arc::new(RwLock::new(IndexMap::new())),
             local_role: Arc::new(RwLock::new(None)),
-        })
-    }
-
-    pub fn start_workers(self: &Arc<Self>) -> JoinSet<()> {
-        let mut set = JoinSet::new();
-        set.spawn(self.clone().refresh_topology_worker());
-        set.spawn(self.clone().refresh_interfaces_worker());
-        set
+        });
+        tokio::spawn(this.clone().refresh_topology_worker());
+        tokio::spawn(this.clone().refresh_interfaces_worker());
+        this
     }
 
     /// ** Returns the local role


### PR DESCRIPTION
- `AL_SAP` restarts were moved to a separate loop, now will not affect other components
- remove `lazy_static` crate, it was used only in one place and is no longer required
- tokio runtime is no longer restarted when something happens to `AL_SAP`
  - TopoDB` workers are now started right away