### PR TITLE
tracing improvements

### DIFF
--- a/ieee1905-core/src/al_sap.rs
+++ b/ieee1905-core/src/al_sap.rs
@@ -31,7 +31,7 @@ use crate::registration_codec::{
 use crate::sdu_codec::SDU;
 use crate::tlv_cmdu_codec::TLVTrait;
 use crate::topology_manager::Role;
-use crate::{TopologyDatabase, next_task_id};
+use crate::{TopologyDatabase, next_task_id, spawn_named};
 use anyhow::{Context, Result, bail};
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
@@ -326,12 +326,15 @@ impl AlServiceAccessPoint {
             self.interface_name
         );
 
-        cmdu_topology_notification_transmission(
-            self.interface_name.clone(),
-            Arc::clone(&self.sender),
-            message_id_generator,
-            al_mac,
-            forwarding_mac,
+        spawn_named(
+            "proxy_topo_notification",
+            cmdu_topology_notification_transmission(
+                self.interface_name.clone(),
+                self.sender.clone(),
+                message_id_generator,
+                al_mac,
+                forwarding_mac,
+            ),
         );
     }
 
@@ -704,10 +707,13 @@ async fn send_cmdu_from_sdu(sdu: SDU) -> Result<()> {
             ));
         }
         tracing::debug!("Sending CMDU part from SDU via network");
-        cmdu_from_sdu_transmission(
-            sap_guard.interface_name.clone(),
-            sap_guard.sender.clone(),
-            sdu.clone(),
+        spawn_named(
+            "cmdu_from_sdu",
+            cmdu_from_sdu_transmission(
+                sap_guard.interface_name.clone(),
+                sap_guard.sender.clone(),
+                sdu.clone(),
+            ),
         );
         Ok(())
     } else {

--- a/ieee1905-core/src/artifact_exchange_service/client.rs
+++ b/ieee1905-core/src/artifact_exchange_service/client.rs
@@ -5,7 +5,7 @@ use crate::artifact_exchange_service::common::{
 use crate::interface_manager::{
     InterfaceInfo, call_rt_new_address_v6, call_rt_remove_address_v6, convert_mac_to_eui64,
 };
-use crate::next_task_id;
+use crate::{next_task_id, spawn_join_set_named, spawn_on_named};
 use futures::StreamExt;
 use pnet::util::MacAddr;
 use reqwest::Url;
@@ -77,10 +77,11 @@ impl Drop for ArtifactExchangeClientFactory {
             ip_address = %self.local_ip_address,
             "clearing ip address to the interface",
         );
-        self.runtime.spawn(call_rt_remove_address_v6(
-            self.if_info.if_index,
-            self.local_ip_address,
-        ));
+        spawn_on_named(
+            "artifact_exchange_client/drop",
+            &self.runtime,
+            call_rt_remove_address_v6(self.if_info.if_index, self.local_ip_address),
+        );
     }
 }
 
@@ -119,7 +120,12 @@ impl ArtifactExchangeClient {
         };
 
         let mut join_set = JoinSet::new();
-        join_set.spawn(actor.worker());
+        spawn_join_set_named(
+            "artifact_exchange_client/worker",
+            None,
+            &mut join_set,
+            actor.worker(),
+        );
 
         Ok(Self {
             base_url: base_url_str.into_owned(),

--- a/ieee1905-core/src/artifact_exchange_service/server.rs
+++ b/ieee1905-core/src/artifact_exchange_service/server.rs
@@ -6,7 +6,7 @@ use crate::artifact_exchange_service::common::ArtifactExchangeConfig;
 use crate::interface_manager::{
     InterfaceInfo, call_rt_new_address_v6, call_rt_remove_address_v6, convert_mac_to_eui64,
 };
-use crate::{TopologyDatabase, next_task_id};
+use crate::{TopologyDatabase, next_task_id, spawn_join_set_named, spawn_on_named};
 use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::routing::{get, put};
@@ -111,7 +111,12 @@ impl ArtifactExchangeServerInstance {
 
         debug!("starting server worker");
         let mut join_set = JoinSet::new();
-        join_set.spawn(ArtifactExchangeServerInstanceActor.worker(listener));
+        spawn_join_set_named(
+            "artifact_exchange_server/worker",
+            None,
+            &mut join_set,
+            ArtifactExchangeServerInstanceActor.worker(listener),
+        );
 
         info!(
             if_name = if_info.if_name,
@@ -139,10 +144,11 @@ impl Drop for ArtifactExchangeServerInstance {
             "clearing ip address to the interface",
         );
         self.topo_db.set_artifact_exchange_server_ip_address(None);
-        self.runtime.spawn(call_rt_remove_address_v6(
-            self.if_info.if_index,
-            self.ip_address,
-        ));
+        spawn_on_named(
+            "artifact_exchange_server/drop",
+            &self.runtime,
+            call_rt_remove_address_v6(self.if_info.if_index, self.ip_address),
+        );
     }
 }
 

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -23,7 +23,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, error, info, instrument, trace, warn};
 
-use crate::MessageIdGenerator;
 use crate::al_sap::{AlServiceAccessPoint, service_access_point_data_indication};
 use crate::cmdu::{CMDU, CMDUType, DeviceInformation};
 use crate::cmdu_codec::*;
@@ -33,6 +32,7 @@ use crate::ethernet_subject_transmission::EthernetSender;
 use crate::sdu_codec::SDU;
 use crate::tlv_cmdu_codec::{TLV, TLVTrait};
 use crate::topology_manager::*;
+use crate::{MessageIdGenerator, spawn_named};
 use pnet::datalink::MacAddr;
 
 ///the handler has to take care of the reassembly
@@ -292,27 +292,31 @@ impl CMDUHandler {
         match transmission_event {
             TransmissionEvent::SendTopologyQuery(destination_al_mac) => {
                 let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-
-                cmdu_topology_query_transmission(
-                    self.interface_name.clone(),
-                    Arc::clone(&self.sender),
-                    Arc::clone(&self.message_id_generator),
-                    self.local_al_mac,
-                    destination_al_mac,
-                    forwarding_interface_mac,
-                )
-                .await;
+                spawn_named(
+                    format!("proxy_topo_query/{destination_al_mac}"),
+                    cmdu_topology_query_transmission(
+                        self.interface_name.clone(),
+                        self.sender.clone(),
+                        self.message_id_generator.clone(),
+                        self.local_al_mac,
+                        destination_al_mac,
+                        forwarding_interface_mac,
+                    ),
+                );
             }
             TransmissionEvent::StartHigherLayerQueryWorker((destination, token)) => {
                 let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-                tokio::spawn(cmdu_higher_layer_query_transmission_worker(
-                    topology_db.clone(),
-                    self.sender.clone(),
-                    self.message_id_generator.clone(),
-                    forwarding_interface_mac,
-                    destination,
-                    token,
-                ));
+                spawn_named(
+                    format!("proxy_hle_query/{destination}"),
+                    cmdu_higher_layer_query_transmission_worker(
+                        topology_db.clone(),
+                        self.sender.clone(),
+                        self.message_id_generator.clone(),
+                        forwarding_interface_mac,
+                        destination,
+                        token,
+                    ),
+                );
             }
             TransmissionEvent::None => {
                 debug!(
@@ -398,13 +402,16 @@ impl CMDUHandler {
 
                 let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
 
-                cmdu_topology_response_transmission(
-                    self.interface_name.clone(),
-                    self.sender.clone(),
-                    self.local_al_mac,
-                    destination_mac,
-                    forwarding_interface_mac,
-                    message_id,
+                spawn_named(
+                    format!("proxy_topo_response/{destination_mac}"),
+                    cmdu_topology_response_transmission(
+                        self.interface_name.clone(),
+                        self.sender.clone(),
+                        self.local_al_mac,
+                        destination_mac,
+                        forwarding_interface_mac,
+                        message_id,
+                    ),
                 );
                 true
             }
@@ -566,12 +573,15 @@ impl CMDUHandler {
 
                 let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
 
-                cmdu_topology_notification_transmission(
-                    self.interface_name.clone(),
-                    Arc::clone(&self.sender),
-                    Arc::clone(&self.message_id_generator),
-                    self.local_al_mac,
-                    forwarding_interface_mac,
+                spawn_named(
+                    "proxy_topo_notification",
+                    cmdu_topology_notification_transmission(
+                        self.interface_name.clone(),
+                        self.sender.clone(),
+                        self.message_id_generator.clone(),
+                        self.local_al_mac,
+                        forwarding_interface_mac,
+                    ),
                 );
                 true
             }
@@ -650,16 +660,17 @@ impl CMDUHandler {
         match transmission_event {
             TransmissionEvent::SendTopologyQuery(dest_mac) => {
                 let forwarding_interface = topology_db.get_forwarding_interface_mac().await;
-
-                cmdu_topology_query_transmission(
-                    self.interface_name.clone(),
-                    self.sender.clone(),
-                    self.message_id_generator.clone(),
-                    self.local_al_mac,
-                    dest_mac,
-                    forwarding_interface,
-                )
-                .await;
+                spawn_named(
+                    format!("proxy_topo_query/{remote_al_mac_address}"),
+                    cmdu_topology_query_transmission(
+                        self.interface_name.clone(),
+                        self.sender.clone(),
+                        self.message_id_generator.clone(),
+                        self.local_al_mac,
+                        dest_mac,
+                        forwarding_interface,
+                    ),
+                );
                 true
             }
             TransmissionEvent::None => {
@@ -695,8 +706,9 @@ impl CMDUHandler {
         info!(source = %source_mac, "Link Metric Query Processed");
 
         if let Some((remote_al_mac, neighbors)) = result {
-            tokio::spawn(cmdu_link_metric_response_transmission(
-                LinkMetricResponseTransmissionRequest {
+            spawn_named(
+                format!("proxy_link_metric_response/{remote_al_mac}"),
+                cmdu_link_metric_response_transmission(LinkMetricResponseTransmissionRequest {
                     interface: self.interface_name.clone(),
                     sender: self.sender.clone(),
                     message_id,
@@ -705,8 +717,8 @@ impl CMDUHandler {
                     include_rx: query.requested_metrics != LinkMetricQuery::METRIC_TX,
                     include_tx: query.requested_metrics != LinkMetricQuery::METRIC_RX,
                     neighbors,
-                },
-            ));
+                }),
+            );
         } else {
             debug!("No transmission event triggered by Link Metric Query");
         }
@@ -785,14 +797,17 @@ impl CMDUHandler {
                     source = %source_mac,
                     "Topology update started link metric query worker"
                 );
-                tokio::spawn(cmdu_link_metric_query_transmission_worker(
-                    topo_db,
-                    self.sender.clone(),
-                    self.message_id_generator.clone(),
-                    local_interface_mac,
-                    destination,
-                    cancellation_token,
-                ));
+                spawn_named(
+                    format!("proxy_link_metric_query/{destination}"),
+                    cmdu_link_metric_query_transmission_worker(
+                        topo_db,
+                        self.sender.clone(),
+                        self.message_id_generator.clone(),
+                        local_interface_mac,
+                        destination,
+                        cancellation_token,
+                    ),
+                );
             }
             TransmissionEvent::None => {
                 debug!(
@@ -867,14 +882,17 @@ impl CMDUHandler {
         let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
         let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
 
-        tokio::spawn(cmdu_higher_layer_response_transmission(
-            self.interface_name.clone(),
-            self.sender.clone(),
-            self.local_al_mac,
-            source_mac,
-            forwarding_interface_mac,
-            message_id,
-        ));
+        spawn_named(
+            format!("proxy_hle_response/{source_mac}"),
+            cmdu_higher_layer_response_transmission(
+                self.interface_name.clone(),
+                self.sender.clone(),
+                self.local_al_mac,
+                source_mac,
+                forwarding_interface_mac,
+                message_id,
+            ),
+        );
 
         info!(source = %source_mac, "HigherLayerQuery Processed");
     }

--- a/ieee1905-core/src/cmdu_observer.rs
+++ b/ieee1905-core/src/cmdu_observer.rs
@@ -20,7 +20,7 @@
 use crate::cmdu::{CMDU, CMDUType};
 use crate::cmdu_handler::CMDUHandler;
 use crate::ethernet_subject_reception::EthernetFrameObserver;
-use crate::next_task_id;
+use crate::{next_task_id, spawn_named};
 use async_trait::async_trait;
 use pnet::datalink::MacAddr;
 use std::sync::Arc;
@@ -66,7 +66,8 @@ impl EthernetFrameObserver for CMDUObserver {
                 //TODO to clean up
                 //let interface_name = handler_ref.interface_name.clone(); // --> not needed for now unles we pass the interface to the handler
 
-                tokio::task::spawn(
+                spawn_named(
+                    format!("handle_cmdu/{}", self.handler.interface_name),
                     async move {
                         if let Err(e) = handler
                             .handle_cmdu(&cmdu, source_mac, destination_mac, interface_mac)
@@ -75,7 +76,7 @@ impl EthernetFrameObserver for CMDUObserver {
                             error!("Failed to handle CMDU: {e:?}");
                         }
                     }
-                    .instrument(info_span!(parent: None, "handle_cmdu", task = next_task_id())),
+                    .instrument(info_span!(parent: None, "handle_cmdu", task = next_task_id(), mac = %source_mac)),
                 );
             }
             Err(e) => {

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -31,7 +31,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::time::{Duration, Instant, interval};
 use tokio_util::sync::CancellationToken;
-use tracing::{Instrument, debug, error, info, info_span, instrument, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 #[instrument(skip_all, name = "cmdu_discovery_transmission", fields(task = next_task_id()))]
 pub async fn cmdu_topology_discovery_transmission_worker(
@@ -99,6 +99,11 @@ pub async fn cmdu_topology_discovery_transmission_worker(
     }
 }
 
+#[instrument(
+    skip_all,
+    name = "cmdu_query_transmission",
+    fields(task = next_task_id(), al_mac = %remote_al_mac_address),
+)]
 pub async fn cmdu_topology_query_transmission(
     interface: String,
     sender: Arc<EthernetSender>,
@@ -107,111 +112,111 @@ pub async fn cmdu_topology_query_transmission(
     remote_al_mac_address: MacAddr,
     interface_mac_address: MacAddr,
 ) {
-    tokio::spawn(
-        async move {
-            let message_id = message_id_generator.next_id();
+    let message_id = message_id_generator.next_id();
+    debug!(
+        interface = %interface,
+        message_id = message_id,
+        "Creating CMDU Topology Query"
+    );
+
+    // Retrieve device data from the topology database
+    let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
+    let Some(node) = topology_db.get_device(remote_al_mac_address).await else {
+        debug!(
+            "Could not find node in topology database for AL_MAC={}",
+            remote_al_mac_address
+        );
+        return;
+    };
+
+    // Clone the device data (without modifying metadata)
+    let device_data = node.device_data.clone();
+
+    // **Retrieve Destination MAC Address**
+    let destination_mac = device_data.destination_frame_mac;
+    let local_role = topology_db.get_local_role().await;
+
+    // Define TLVs
+    let payload = [
+        Some(TLV::from(AlMacAddress {
+            al_mac_address: local_al_mac_address,
+        })),
+        Some(TLV::from(VendorSpecificInfo {
+            oui: COMCAST_OUI,
+            vendor_data: COMCAST_QUERY_TAG,
+        })),
+        if let Some(Role::Registrar) = local_role {
+            Some(TLV::from(MultiApProfile::Profile3))
+        } else {
+            None
+        },
+        Some(TLV::from(EndOfMessage)),
+    ];
+
+    // Construct CMDU
+    let cmdu_topology_query = CMDU {
+        message_version: MessageVersion::Version2013.to_u8(),
+        reserved: 0,
+        message_type: CMDUType::TopologyQuery.to_u16(),
+        message_id,
+        fragment: 0,
+        flags: 0x80,
+        payload: payload.iter().flatten().flat_map(TLV::serialize).collect(),
+    };
+
+    let serialized_cmdu = cmdu_topology_query.serialize();
+    debug!(
+        message_id = message_id,
+        ?serialized_cmdu,
+        "Serialized CMDU for Topology Query"
+    );
+
+    let source_mac = interface_mac_address;
+    let ethertype = 0x893A; // IEEE 1905 EtherType
+
+    // Send the CMDU via EthernetSender
+    match sender
+        .enqueue_frame(destination_mac, source_mac, ethertype, serialized_cmdu)
+        .await
+    {
+        Err(e) => {
+            error!(
+                message_id = message_id,
+                "Failed to send CMDU Topology Query: {}", e
+            );
+        }
+        Ok(()) => {
             debug!(
                 interface = %interface,
                 message_id = message_id,
-                "Creating CMDU Topology Query"
+                al_mac = %local_al_mac_address,
+                "CMDU Topology Query sent successfully"
             );
 
-            // Retrieve device data from the topology database
-            let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
-            let Some(node) = topology_db.get_device(remote_al_mac_address).await else {
-                debug!(
-                    "Could not find node in topology database for AL_MAC={}",
-                    remote_al_mac_address
-                );
-                return;
-            };
-
-            // Clone the device data (without modifying metadata)
-            let device_data = node.device_data.clone();
-
-            // **Retrieve Destination MAC Address**
-            let destination_mac = device_data.destination_frame_mac;
-            let local_role = topology_db.get_local_role().await;
-
-            // Define TLVs
-            let payload = [
-                Some(TLV::from(AlMacAddress {
-                    al_mac_address: local_al_mac_address,
-                })),
-                Some(TLV::from(VendorSpecificInfo {
-                    oui: COMCAST_OUI,
-                    vendor_data: COMCAST_QUERY_TAG,
-                })),
-                if let Some(Role::Registrar) = local_role {
-                    Some(TLV::from(MultiApProfile::Profile3))
-                } else {
-                    None
-                },
-                Some(TLV::from(EndOfMessage)),
-            ];
-
-            // Construct CMDU
-            let cmdu_topology_query = CMDU {
-                message_version: MessageVersion::Version2013.to_u8(),
-                reserved: 0,
-                message_type: CMDUType::TopologyQuery.to_u16(),
-                message_id,
-                fragment: 0,
-                flags: 0x80,
-                payload: payload.iter().flatten().flat_map(TLV::serialize).collect(),
-            };
-
-            let serialized_cmdu = cmdu_topology_query.serialize();
+            // **Update the node's state to `QUERY_SENT` in the topology database**
+            topology_db
+                .update_ieee1905_topology(
+                    device_data.clone(),
+                    UpdateType::QuerySent,
+                    Some(message_id),
+                    None,
+                    None,
+                )
+                .await;
             debug!(
-                message_id = message_id,
-                ?serialized_cmdu,
-                "Serialized CMDU for Topology Query"
+                "Updated topology database: AL_MAC={} set to QUERY_SENT",
+                remote_al_mac_address
             );
-
-            let source_mac = interface_mac_address;
-            let ethertype = 0x893A; // IEEE 1905 EtherType
-
-            // Send the CMDU via EthernetSender
-            match sender
-                .enqueue_frame(destination_mac, source_mac, ethertype, serialized_cmdu)
-                .await
-            {
-                Err(e) => {
-                    error!(
-                        message_id = message_id,
-                        "Failed to send CMDU Topology Query: {}", e
-                    );
-                }
-                Ok(()) => {
-                    debug!(
-                        interface = %interface,
-                        message_id = message_id,
-                        al_mac = %local_al_mac_address,
-                        "CMDU Topology Query sent successfully"
-                    );
-
-                    // **Update the node's state to `QUERY_SENT` in the topology database**
-                    topology_db
-                        .update_ieee1905_topology(
-                            device_data.clone(),
-                            UpdateType::QuerySent,
-                            Some(message_id),
-                            None,
-                            None,
-                        )
-                        .await;
-                    debug!(
-                        "Updated topology database: AL_MAC={} set to QUERY_SENT",
-                        remote_al_mac_address
-                    );
-                }
-            }
         }
-        .instrument(info_span!(parent: None, "cmdu_query_transmission", task = next_task_id())),
-    );
+    }
 }
 
-pub fn cmdu_topology_response_transmission(
+#[instrument(
+    skip_all,
+    name = "cmdu_response_transmission",
+    fields(task = next_task_id(), al_mac = %remote_al_mac_address),
+)]
+pub async fn cmdu_topology_response_transmission(
     interface: String,
     sender: Arc<EthernetSender>,
     local_al_mac_address: MacAddr,
@@ -219,89 +224,83 @@ pub fn cmdu_topology_response_transmission(
     interface_mac_address: MacAddr,
     message_id: u16,
 ) {
-    tokio::spawn(
-        async move {
-            //let message_id = message_id_generator.next_id();
-            trace!(
-                interface = %interface,
-                "Creating CMDU Topology Response"
-            );
-
-            // Retrieve node information from the topology database
-            let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
-            let Some(node) = topology_db.get_device(remote_al_mac_address).await else {
-                warn!(
-                    "Could not find node in topology database for AL_MAC={}",
-                    remote_al_mac_address
-                );
-                return;
-            };
-
-            // Retrieve Forwarding MAC Address from Database
-            let destination_mac = node.device_data.destination_frame_mac;
-            let fragmentation = node.device_data.supported_fragmentation;
-
-            // Building TLV payload
-            let mut payload = vec![
-                TLV::from(AlMacAddress {
-                    al_mac_address: local_al_mac_address,
-                }),
-                TLV::from(EndOfMessage),
-            ];
-
-            if let Err(e) = inject_topology_response_tlvs(&mut payload, &topology_db).await {
-                return error!(%e, "failed to inject topo TLVs");
-            }
-
-            // Construct the CMDU
-            let cmdu_topology_response = CMDU {
-                message_version: MessageVersion::Version2013.to_u8(),
-                reserved: 0,
-                message_type: CMDUType::TopologyResponse.to_u16(),
-                message_id,
-                fragment: 0,
-                flags: 0x80, // Not fragmented
-                payload: payload.iter().flat_map(TLV::serialize).collect(),
-            };
-
-            let send_future = enqueue_fragmented_cmdu(
-                &sender,
-                destination_mac,
-                interface_mac_address,
-                cmdu_topology_response,
-                fragmentation,
-            );
-
-            match send_future.await {
-                Ok(_) => {
-                    info!(
-                        interface = %interface,
-                        message_id = message_id,
-                        "CMDU Topology Response sent successfully"
-                    );
-
-                    // **Update Topology Database to RESPONSE_SENT**
-
-                    topology_db
-                        .update_ieee1905_topology(
-                            node.device_data.clone(),
-                            UpdateType::ResponseSent,
-                            None,
-                            None,
-                            None,
-                        )
-                        .await;
-
-                    info!("Topology Database updated: AL_MAC={local_al_mac_address} set to ResponseSent");
-                }
-                Err(e) => error!(
-                    message_id = message_id,
-                    "Failed to send CMDU Topology Response: {e}",
-                ),
-            }
-        }
-            .instrument(info_span!(parent: None, "cmdu_response_transmission", task = next_task_id())),
+    trace!(
+        interface = %interface,
+        "Creating CMDU Topology Response"
     );
+
+    // Retrieve node information from the topology database
+    let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
+    let Some(node) = topology_db.get_device(remote_al_mac_address).await else {
+        warn!(
+            "Could not find node in topology database for AL_MAC={}",
+            remote_al_mac_address
+        );
+        return;
+    };
+
+    // Retrieve Forwarding MAC Address from Database
+    let destination_mac = node.device_data.destination_frame_mac;
+    let fragmentation = node.device_data.supported_fragmentation;
+
+    // Building TLV payload
+    let mut payload = vec![
+        TLV::from(AlMacAddress {
+            al_mac_address: local_al_mac_address,
+        }),
+        TLV::from(EndOfMessage),
+    ];
+
+    if let Err(e) = inject_topology_response_tlvs(&mut payload, &topology_db).await {
+        return error!(%e, "failed to inject topo TLVs");
+    }
+
+    // Construct the CMDU
+    let cmdu_topology_response = CMDU {
+        message_version: MessageVersion::Version2013.to_u8(),
+        reserved: 0,
+        message_type: CMDUType::TopologyResponse.to_u16(),
+        message_id,
+        fragment: 0,
+        flags: 0x80, // Not fragmented
+        payload: payload.iter().flat_map(TLV::serialize).collect(),
+    };
+
+    let send_future = enqueue_fragmented_cmdu(
+        &sender,
+        destination_mac,
+        interface_mac_address,
+        cmdu_topology_response,
+        fragmentation,
+    );
+
+    match send_future.await {
+        Ok(_) => {
+            info!(
+                interface = %interface,
+                message_id = message_id,
+                "CMDU Topology Response sent successfully"
+            );
+
+            // **Update Topology Database to RESPONSE_SENT**
+
+            topology_db
+                .update_ieee1905_topology(
+                    node.device_data.clone(),
+                    UpdateType::ResponseSent,
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+
+            info!("Topology Database updated: AL_MAC={local_al_mac_address} set to ResponseSent");
+        }
+        Err(e) => error!(
+            message_id = message_id,
+            "Failed to send CMDU Topology Response: {e}",
+        ),
+    }
 }
 
 async fn inject_topology_response_tlvs(
@@ -436,90 +435,88 @@ async fn inject_topology_response_tlvs(
     Ok(())
 }
 
-pub fn cmdu_topology_notification_transmission(
+#[instrument(skip_all, name = "cmdu_notification_transmission", fields(task = next_task_id()))]
+pub async fn cmdu_topology_notification_transmission(
     interface: String,
     sender: Arc<EthernetSender>,
     message_id_generator: Arc<MessageIdGenerator>,
     local_al_mac_address: MacAddr,
     forwarding_interface_mac: MacAddr,
 ) {
-    tokio::spawn(
-        async move {
-            let message_id = message_id_generator.next_id();
-            trace!(
+    let message_id = message_id_generator.next_id();
+    trace!(
+        interface = %interface,
+        message_id = message_id,
+        "Creating CMDU Topology Notification"
+    );
+
+    info!(
+        "Updated topology database: MSGId={} set to NotificationSent",
+        message_id
+    );
+
+    let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
+
+    let payload = [
+        TLV::from(AlMacAddress {
+            al_mac_address: local_al_mac_address,
+        }),
+        TLV::from(VendorSpecificInfo {
+            oui: COMCAST_OUI,
+            vendor_data: COMCAST_QUERY_TAG,
+        }),
+        TLV::from(EndOfMessage),
+    ];
+
+    // Construct the Topology Notification CMDU
+    let cmdu_topology_notification = CMDU {
+        message_version: MessageVersion::Version2013.to_u8(),
+        reserved: 0,
+        message_type: CMDUType::TopologyNotification.to_u16(),
+        message_id,
+        fragment: 0,
+        flags: 0x80, // Not fragmented
+        payload: payload.iter().flat_map(TLV::serialize).collect(),
+    };
+
+    // Serialize CMDU
+    let serialized_cmdu = cmdu_topology_notification.serialize();
+    debug!(
+        message_id = message_id,
+        ?serialized_cmdu,
+        "Serialized CMDU for Topology Notification"
+    );
+
+    // Set IEEE 1905 multicast destination MAC
+    let destination_mac = MacAddr::new(0x01, 0x80, 0xC2, 0x00, 0x00, 0x13);
+    let source_mac = forwarding_interface_mac;
+    let ethertype = 0x893A; // IEEE 1905 EtherType
+
+    // Send the CMDU via EthernetSender
+    match sender
+        .send_frame(destination_mac, source_mac, ethertype, serialized_cmdu)
+        .await
+    {
+        Ok(()) => {
+            info!(
                 interface = %interface,
                 message_id = message_id,
-                "Creating CMDU Topology Notification"
+                "CMDU Topology Notification sent successfully"
             );
-
-            info!(
-                "Updated topology database: MSGId={} set to NotificationSent",
-                message_id
-            );
-
-            let topology_db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
-
-            let payload = [
-                TLV::from(AlMacAddress {
-                    al_mac_address: local_al_mac_address,
-                }),
-                TLV::from(VendorSpecificInfo {
-                    oui: COMCAST_OUI,
-                    vendor_data: COMCAST_QUERY_TAG,
-                }),
-                TLV::from(EndOfMessage),
-            ];
-
-            // Construct the Topology Notification CMDU
-            let cmdu_topology_notification = CMDU {
-                message_version: MessageVersion::Version2013.to_u8(),
-                reserved: 0,
-                message_type: CMDUType::TopologyNotification.to_u16(),
-                message_id,
-                fragment: 0,
-                flags: 0x80, // Not fragmented
-                payload: payload.iter().flat_map(TLV::serialize).collect(),
-            };
-
-            // Serialize CMDU
-            let serialized_cmdu = cmdu_topology_notification.serialize();
-            debug!(
-                message_id = message_id,
-                ?serialized_cmdu,
-                "Serialized CMDU for Topology Notification"
-            );
-
-            // Set IEEE 1905 multicast destination MAC
-            let destination_mac = MacAddr::new(0x01, 0x80, 0xC2, 0x00, 0x00, 0x13);
-            let source_mac = forwarding_interface_mac;
-            let ethertype = 0x893A; // IEEE 1905 EtherType
-
-            // Send the CMDU via EthernetSender
-            match sender
-                .send_frame(destination_mac, source_mac, ethertype, serialized_cmdu)
-                .await
-            {
-                Ok(()) => {
-                    info!(
-                        interface = %interface,
-                        message_id = message_id,
-                        "CMDU Topology Notification sent successfully"
-                    );
-                    topology_db.handle_notification_sent().await;
-                }
-                Err(e) => error!(
-                    message_id = message_id,
-                    "Failed to send CMDU Topology Notification: {}", e
-                ),
-            }
+            topology_db.handle_notification_sent().await;
         }
-        .instrument(
-            info_span!(parent: None, "cmdu_notification_transmission", task = next_task_id()),
+        Err(e) => error!(
+            message_id = message_id,
+            "Failed to send CMDU Topology Notification: {}", e
         ),
-    );
+    }
 }
 
-#[instrument(skip_all, name = "cmdu_link_metric_query_transmission", fields(task = next_task_id()))]
+#[instrument(
+    skip_all,
+    name = "cmdu_link_metric_query_transmission",
+    fields(task = next_task_id(), mac = %destination_mac),
+)]
 pub async fn cmdu_link_metric_query_transmission_worker(
     topo_db: Arc<TopologyDatabase>,
     sender: Arc<EthernetSender>,
@@ -593,7 +590,11 @@ pub struct LinkMetricResponseTransmissionRequest {
     pub neighbors: Vec<Ieee1905Node>,
 }
 
-#[instrument(skip_all, name = "cmdu_link_metric_response_transmission", fields(task = next_task_id()))]
+#[instrument(
+    skip_all,
+    name = "cmdu_link_metric_response_transmission",
+    fields(task = next_task_id(), al_mac = %request.remote_al_mac_address),
+)]
 pub async fn cmdu_link_metric_response_transmission(
     request: LinkMetricResponseTransmissionRequest,
 ) {
@@ -726,6 +727,11 @@ pub async fn cmdu_link_metric_response_transmission(
     }
 }
 
+#[instrument(
+    skip_all,
+    name = "cmdu_higher_layer_query_worker",
+    fields(task = next_task_id(), mac = %destination_mac),
+)]
 pub async fn cmdu_higher_layer_query_transmission_worker(
     topo_db: Arc<TopologyDatabase>,
     sender: Arc<EthernetSender>,
@@ -776,7 +782,11 @@ pub async fn cmdu_higher_layer_query_transmission_worker(
     }
 }
 
-#[instrument(skip_all, name = "cmdu_higher_layer_response_transmission", fields(task = next_task_id()))]
+#[instrument(
+    skip_all,
+    name = "cmdu_higher_layer_response_transmission",
+    fields(task = next_task_id(), al_mac = %remote_al_mac_address),
+)]
 pub async fn cmdu_higher_layer_response_transmission(
     interface: String,
     sender: Arc<EthernetSender>,
@@ -846,64 +856,73 @@ pub async fn cmdu_higher_layer_response_transmission(
     }
 }
 
-pub fn cmdu_from_sdu_transmission(interface: String, sender: Arc<EthernetSender>, sdu: SDU) {
-    tokio::spawn(async move {
-        if !AlServiceAccessPoint::is_connected_and_enabled().await {
-            return info!("AlSap is not active, ignoring SDU");
-        }
+#[instrument(
+    skip_all,
+    name = "cmdu_from_sdu_transmission",
+    fields(task = next_task_id(), mac = %sdu.destination_al_mac_address),
+)]
+pub async fn cmdu_from_sdu_transmission(interface: String, sender: Arc<EthernetSender>, sdu: SDU) {
+    if !AlServiceAccessPoint::is_connected_and_enabled().await {
+        return info!("AlSap is not active, ignoring SDU");
+    }
 
-        trace!(?sdu, "Parsing CMDU from SDU payload");
-        let source_al_mac = sdu.source_al_mac_address;
-        let destination_al_mac = sdu.destination_al_mac_address;
-        let fragmentation;
+    trace!(?sdu, "Parsing CMDU from SDU payload");
+    let source_al_mac = sdu.source_al_mac_address;
+    let destination_al_mac = sdu.destination_al_mac_address;
+    let fragmentation;
 
-        match CMDU::parse(&sdu.payload) {
-            Ok((_, mut cmdu)) => {
-                let topology_db = TopologyDatabase::get_instance(source_al_mac, &interface);
-                let destination_mac = if sdu.destination_al_mac_address == IEEE1905_CONTROL_ADDRESS {
-                    trace!("Parsing CMDU from SDU payload destination mac address is IEEE1905_CONTROL_ADDRESS");
-                    fragmentation = CMDUFragmentation::default();
-                    IEEE1905_CONTROL_ADDRESS
-                } else {
-                    trace!("Acquiry topology database for source al mac address {source_al_mac}");
-                    trace!("Searching for destination {destination_al_mac} in topology database");
+    match CMDU::parse(&sdu.payload) {
+        Ok((_, mut cmdu)) => {
+            let topology_db = TopologyDatabase::get_instance(source_al_mac, &interface);
+            let destination_mac = if sdu.destination_al_mac_address == IEEE1905_CONTROL_ADDRESS {
+                trace!(
+                    "Parsing CMDU from SDU payload destination mac address is IEEE1905_CONTROL_ADDRESS"
+                );
+                fragmentation = CMDUFragmentation::default();
+                IEEE1905_CONTROL_ADDRESS
+            } else {
+                trace!("Acquiry topology database for source al mac address {source_al_mac}");
+                trace!("Searching for destination {destination_al_mac} in topology database");
 
-                    let Some(node) = topology_db.get_device(sdu.destination_al_mac_address).await else {
-                        return warn!("No destination_mac found for AL-MAC {destination_al_mac}");
-                    };
-
-                    fragmentation = node.device_data.supported_fragmentation;
-                    node.device_data.destination_frame_mac
+                let Some(node) = topology_db.get_device(sdu.destination_al_mac_address).await
+                else {
+                    return warn!("No destination_mac found for AL-MAC {destination_al_mac}");
                 };
 
-                let source_mac = match get_mac_address_by_interface(&interface) {
-                    Some(mac) => mac,
-                    None => {
-                        return warn!("Interface {} not found or has no MAC address", interface);
-                    }
+                fragmentation = node.device_data.supported_fragmentation;
+                node.device_data.destination_frame_mac
+            };
+
+            let source_mac = match get_mac_address_by_interface(&interface) {
+                Some(mac) => mac,
+                None => {
+                    return warn!("Interface {} not found or has no MAC address", interface);
+                }
+            };
+
+            if cmdu.message_type == CMDUType::TopologyResponse.to_u16() {
+                let Ok(mut tlvs) = cmdu.get_tlvs() else {
+                    return error!("Failed to parse topo response TLVs");
                 };
-
-                if cmdu.message_type == CMDUType::TopologyResponse.to_u16() {
-                    let Ok(mut tlvs) = cmdu.get_tlvs() else {
-                        return error!("Failed to parse topo response TLVs");
-                    };
-                    if let Err(e) = inject_topology_response_tlvs(&mut tlvs, &topology_db).await {
-                        return error!(%e, "Failed to inject topo response TLVs");
-                    }
-                    debug!("injecting topology response TLVs");
-                    cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
-                    trace!(?cmdu, "injected topology response TLVs");
+                if let Err(e) = inject_topology_response_tlvs(&mut tlvs, &topology_db).await {
+                    return error!(%e, "Failed to inject topo response TLVs");
                 }
-
-                if let Err(e) = enqueue_fragmented_cmdu(&sender, destination_mac, source_mac, cmdu, fragmentation).await {
-                    error!("Failed to send CMDU: {e}");
-                }
+                debug!("injecting topology response TLVs");
+                cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
+                trace!(?cmdu, "injected topology response TLVs");
             }
-            Err(_) => {
-                error!("Failed to parse CMDU from SDU payload!");
+
+            if let Err(e) =
+                enqueue_fragmented_cmdu(&sender, destination_mac, source_mac, cmdu, fragmentation)
+                    .await
+            {
+                error!("Failed to send CMDU: {e}");
             }
         }
-    }.instrument(info_span!(parent: None, "cmdu_from_sdu_transmission", task = next_task_id())));
+        Err(_) => {
+            error!("Failed to parse CMDU from SDU payload!");
+        }
+    }
 }
 
 async fn enqueue_fragmented_cmdu(

--- a/ieee1905-core/src/cmdu_reassembler.rs
+++ b/ieee1905-core/src/cmdu_reassembler.rs
@@ -18,7 +18,7 @@
 */
 
 use crate::cmdu::CMDU;
-use crate::next_task_id;
+use crate::{next_task_id, spawn_join_set_named};
 use pnet::datalink::MacAddr;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
@@ -27,7 +27,7 @@ use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 use tokio::time::Duration;
-use tracing::{Instrument, info_span};
+use tracing::info_span;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum CmduReassemblyError {
@@ -58,49 +58,39 @@ impl CmduReassembler {
         let buffer_clone = buffer.clone();
 
         let mut join_set = JoinSet::new();
-        join_set.spawn(
-            async move {
-                let mut ticker = tokio::time::interval(Duration::from_secs(3));
+        let span = info_span!(parent: None, "cmdu_reassembler_cleaner", task = next_task_id());
+        spawn_join_set_named("cmdu_reassembler", Some(span), &mut join_set, async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(3));
 
-                loop {
-                    ticker.tick().await;
+            loop {
+                ticker.tick().await;
 
-                    let mut buffer = buffer_clone.lock().await;
-                    let now = Instant::now();
+                let mut buffer = buffer_clone.lock().await;
+                let now = Instant::now();
 
-                    buffer.retain(|key, entry| {
-                        let elapsed = now.duration_since(entry.first_received);
+                buffer.retain(|key, entry| {
+                    let elapsed = now.duration_since(entry.first_received);
 
-                        if elapsed > Duration::from_secs(3) {
-                            if entry.fragments.is_empty() {
-                                tracing::error!("Reassembly error for {:?}: EmptyFragments", key);
-                            } else if !entry.fragments.values().any(|f| f.is_last_fragment()) {
-                                tracing::error!(
-                                    "Reassembly error for {:?}: MissingLastFragment",
-                                    key
-                                );
-                            } else {
-                                let last_id = entry.fragments.keys().max().cloned().unwrap_or(0);
-                                if entry.fragments.len() < (last_id + 1) as usize {
-                                    tracing::error!(
-                                        "Reassembly error for {:?}: MissingFragments",
-                                        key
-                                    );
-                                }
-                            }
-                            tracing::trace!("Other CMDU's did not arrive removing the reassembler");
-                            false // remove expired entry
+                    if elapsed > Duration::from_secs(3) {
+                        if entry.fragments.is_empty() {
+                            tracing::error!("Reassembly error for {:?}: EmptyFragments", key);
+                        } else if !entry.fragments.values().any(|f| f.is_last_fragment()) {
+                            tracing::error!("Reassembly error for {:?}: MissingLastFragment", key);
                         } else {
-                            tracing::trace!("Waiting for rest of the packets!");
-                            true // keep
+                            let last_id = entry.fragments.keys().max().cloned().unwrap_or(0);
+                            if entry.fragments.len() < (last_id + 1) as usize {
+                                tracing::error!("Reassembly error for {:?}: MissingFragments", key);
+                            }
                         }
-                    });
-                }
+                        tracing::trace!("Other CMDU's did not arrive removing the reassembler");
+                        false // remove expired entry
+                    } else {
+                        tracing::trace!("Waiting for rest of the packets!");
+                        true // keep
+                    }
+                });
             }
-            .instrument(
-                info_span!(parent: None, "cmdu_reassembler_cleaner", task = next_task_id()),
-            ),
-        );
+        });
 
         Self {
             _join_set: join_set,

--- a/ieee1905-core/src/ethernet_subject_reception.rs
+++ b/ieee1905-core/src/ethernet_subject_reception.rs
@@ -20,7 +20,7 @@
 #![deny(warnings)]
 
 // External crates
-use crate::next_task_id;
+use crate::{next_task_id, spawn_join_set_blocking_named, spawn_join_set_named};
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use pnet::datalink::{self, Channel::Ethernet, Config};
@@ -33,7 +33,7 @@ use std::io::ErrorKind;
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
 use tokio::task::{JoinSet, yield_now};
-use tracing::{Instrument, debug, error, info, info_span, warn};
+use tracing::{debug, error, info, info_span, warn};
 
 /// Observer trait for handling specific Ethernet frame types
 #[async_trait]
@@ -91,42 +91,39 @@ impl EthernetReceiver {
         let (observer_tx, mut observer_rx) = tokio::sync::mpsc::channel(1000);
         observer_entry.insert(observer_tx);
 
-        self.join_set.spawn(
-            async move {
-                debug!("Observer task started for EtherType: 0x{:04X}", ether_type);
+        let span = info_span!(parent: None, "ethernet_receiver_dispatch", task = next_task_id());
+        let name = format!("eth_recv/{ether_type:04x}");
+        spawn_join_set_named(name, Some(span), &mut self.join_set, async move {
+            debug!("Observer task started for EtherType: 0x{:04X}", ether_type);
 
-                while let Some(message) = observer_rx.recv().await {
-                    debug!(
-                        interface_mac = ?message.interface_mac,
-                        source_mac = ?message.source_mac,
-                        destination_mac = ?message.destination_mac,
-                        frame_length = message.payload.len(),
-                        "Observer received frame"
-                    );
+            while let Some(message) = observer_rx.recv().await {
+                debug!(
+                    interface_mac = ?message.interface_mac,
+                    source_mac = ?message.source_mac,
+                    destination_mac = ?message.destination_mac,
+                    frame_length = message.payload.len(),
+                    "Observer received frame"
+                );
 
-                    observer
-                        .on_frame(
-                            message.interface_mac,
-                            &message.payload,
-                            message.source_mac,
-                            message.destination_mac,
-                        )
-                        .await;
+                observer
+                    .on_frame(
+                        message.interface_mac,
+                        &message.payload,
+                        message.source_mac,
+                        message.destination_mac,
+                    )
+                    .await;
 
-                    // TODO this looks like a "magic delay" workaround and
-                    //  should be properly fixed on the reassembler side
+                // TODO this looks like a "magic delay" workaround and
+                //  should be properly fixed on the reassembler side
 
-                    // To avoid situation when cmdu part with flag end
-                    // is processed before first one
-                    // yield will casue that reassembler is triggered for with
-                    // respect to the arrival of packets.
-                    yield_now().await;
-                }
+                // To avoid situation when cmdu part with flag end
+                // is processed before first one
+                // yield will casue that reassembler is triggered for with
+                // respect to the arrival of packets.
+                yield_now().await;
             }
-            .instrument(
-                info_span!(parent: None, "ethernet_receiver_dispatch", task = next_task_id()),
-            ),
-        );
+        });
     }
 
     /// **Start receiving Ethernet frames**
@@ -158,7 +155,8 @@ impl EthernetReceiver {
             Err(e) => bail!("Failed to create datalink channel: {e}"),
         };
 
-        self.join_set.spawn_blocking(move || {
+        let name = format!("eth_recv/{interface_name}/block");
+        spawn_join_set_blocking_named(name, &mut self.join_set, move || {
             let _span = info_span!(parent: None, "ethernet_receiver_reader", task = next_task_id())
                 .entered();
 
@@ -200,33 +198,30 @@ impl EthernetReceiver {
         });
 
         // TODO this intermediate channel is not needed and can be removed
-        self.join_set.spawn(
-            async move {
-                while let Some(message) = notify_rx.recv().await {
-                    let ether_type = message.ether_type;
-                    let Some(observer) = self.observers.get(&ether_type) else {
-                        continue;
-                    };
+        let span = info_span!(parent: None, "eth_recv_intermediate", task = next_task_id());
+        let name = format!("eth_recv/{interface_name}");
+        spawn_join_set_named(name, Some(span), &mut self.join_set, async move {
+            while let Some(message) = notify_rx.recv().await {
+                let ether_type = message.ether_type;
+                let Some(observer) = self.observers.get(&ether_type) else {
+                    continue;
+                };
 
-                    debug!(
-                        eth_type = format!("0x{ether_type:04X}"),
-                        src = %message.source_mac,
-                        dst = %message.destination_mac,
-                        payload_len = message.payload.len(),
-                        "Received Ethernet frame"
-                    );
+                debug!(
+                    eth_type = format!("0x{ether_type:04X}"),
+                    src = %message.source_mac,
+                    dst = %message.destination_mac,
+                    payload_len = message.payload.len(),
+                    "Received Ethernet frame"
+                );
 
-                    if observer.send(message).await.is_ok() {
-                        debug!("Notified observer for EtherType: 0x{ether_type:04X}");
-                    } else {
-                        error!("Failed to notify observer for EtherType: 0x{ether_type:04X}");
-                    }
+                if observer.send(message).await.is_ok() {
+                    debug!("Notified observer for EtherType: 0x{ether_type:04X}");
+                } else {
+                    error!("Failed to notify observer for EtherType: 0x{ether_type:04X}");
                 }
             }
-            .instrument(
-                info_span!(parent: None, "ethernet_receiver_intermediate", task = next_task_id()),
-            ),
-        );
+        });
         Ok(self.join_set)
     }
 }

--- a/ieee1905-core/src/ethernet_subject_transmission.rs
+++ b/ieee1905-core/src/ethernet_subject_transmission.rs
@@ -16,13 +16,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-use crate::next_task_id;
+use crate::{next_task_id, spawn_join_set_named};
 use anyhow::anyhow;
 use pnet::datalink::MacAddr;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
 use tokio::task::JoinSet;
-use tracing::{Instrument, debug, error, info, info_span, warn};
+use tracing::{debug, error, info, info_span, warn};
 
 #[derive(Debug)]
 struct Frame {
@@ -49,72 +49,71 @@ impl EthernetSender {
         let interface_name = interface_name.to_string();
 
         let mut join_set = JoinSet::new();
-        join_set.spawn(
-            async move {
-                info!(interface_name = %interface_name, "Async sender task initialized");
+        let span = info_span!(parent: None, "ethernet_sender", task = next_task_id());
+        let name = format!("eth_send/{interface_name}");
+        spawn_join_set_named(name, Some(span), &mut join_set, async move {
+            info!(interface_name = %interface_name, "Async sender task initialized");
 
-                let interfaces = pnet::datalink::interfaces();
-                let interface = match interfaces
-                    .into_iter()
-                    .find(|iface| iface.name == interface_name)
-                {
-                    Some(iface) => iface,
-                    None => {
-                        error!(interface_name = %interface_name, "Interface not found");
-                        return;
-                    }
-                };
-
-                info!(interface_name = %interface.name, "Found network interface");
-
-                let config = pnet::datalink::Config::default();
-                let (mut tx, _rx) = match pnet::datalink::channel(&interface, config) {
-                    Ok(pnet::datalink::Channel::Ethernet(tx, rx)) => (tx, rx),
-                    Ok(_) => {
-                        error!("Unsupported channel type");
-                        return;
-                    }
-                    Err(e) => {
-                        error!("Failed to create datalink channel: {}", e);
-                        return;
-                    }
-                };
-
-                debug!("Async sender task is processing frames...");
-
-                while let Some(frame) = rx.recv().await {
-                    debug!(
-                        destination_mac = ?frame.destination_mac,
-                        source_mac = ?frame.source_mac,
-                        ethertype = format!("0x{:04X}", frame.ethertype),
-                        payload_length = frame.payload.len(),
-                        "Processing outgoing Ethernet frame"
-                    );
-
-                    let _lock = interface_mutex.lock().await;
-
-                    let mut buffer = vec![0u8; 14 + frame.payload.len()];
-                    buffer[..6].copy_from_slice(&frame.destination_mac.octets());
-                    buffer[6..12].copy_from_slice(&frame.source_mac.octets());
-                    buffer[12..14].copy_from_slice(&frame.ethertype.to_be_bytes());
-                    buffer[14..].copy_from_slice(&frame.payload);
-
-                    match tx.send_to(&buffer, None) {
-                        Some(Ok(())) => {
-                            if let Some(e) = frame.success_channel {
-                                let _ = e.send(());
-                            }
-                            debug!("Frame sent successfully")
-                        }
-                        Some(Err(e)) => error!("Failed to send frame: {:?}", e),
-                        None => warn!("No transmit descriptor available"),
-                    }
+            let interfaces = pnet::datalink::interfaces();
+            let interface = match interfaces
+                .into_iter()
+                .find(|iface| iface.name == interface_name)
+            {
+                Some(iface) => iface,
+                None => {
+                    error!(interface_name = %interface_name, "Interface not found");
+                    return;
                 }
+            };
 
-                warn!("Async sender task exiting.");
+            info!(interface_name = %interface.name, "Found network interface");
+
+            let config = pnet::datalink::Config::default();
+            let (mut tx, _rx) = match pnet::datalink::channel(&interface, config) {
+                Ok(pnet::datalink::Channel::Ethernet(tx, rx)) => (tx, rx),
+                Ok(_) => {
+                    error!("Unsupported channel type");
+                    return;
+                }
+                Err(e) => {
+                    error!("Failed to create datalink channel: {}", e);
+                    return;
+                }
+            };
+
+            debug!("Async sender task is processing frames...");
+
+            while let Some(frame) = rx.recv().await {
+                debug!(
+                    destination_mac = ?frame.destination_mac,
+                    source_mac = ?frame.source_mac,
+                    ethertype = format!("0x{:04X}", frame.ethertype),
+                    payload_length = frame.payload.len(),
+                    "Processing outgoing Ethernet frame"
+                );
+
+                let _lock = interface_mutex.lock().await;
+
+                let mut buffer = vec![0u8; 14 + frame.payload.len()];
+                buffer[..6].copy_from_slice(&frame.destination_mac.octets());
+                buffer[6..12].copy_from_slice(&frame.source_mac.octets());
+                buffer[12..14].copy_from_slice(&frame.ethertype.to_be_bytes());
+                buffer[14..].copy_from_slice(&frame.payload);
+
+                match tx.send_to(&buffer, None) {
+                    Some(Ok(())) => {
+                        if let Some(e) = frame.success_channel {
+                            let _ = e.send(());
+                        }
+                        debug!("Frame sent successfully")
+                    }
+                    Some(Err(e)) => error!("Failed to send frame: {:?}", e),
+                    None => warn!("No transmit descriptor available"),
+                }
             }
-            .instrument(info_span!(parent: None, "ethernet_sender", task = next_task_id())),
-        );
+
+            warn!("Async sender task exiting.");
+        });
 
         Self {
             _join_set: join_set,

--- a/ieee1905-core/src/lib.rs
+++ b/ieee1905-core/src/lib.rs
@@ -18,7 +18,6 @@
 */
 
 #![deny(warnings)]
-// ───── Base modules ─────
 pub mod al_sap;
 pub mod cmdu_codec;
 pub mod cmdu_handler;
@@ -43,7 +42,6 @@ pub mod topology_manager;
 #[cfg(feature = "rbus")]
 pub mod rbus;
 
-// ───── Submodules: TLVs grouped under namespaces ─────
 pub mod lldpdu {
     pub use crate::lldpdu_codec::{ChassisId, LLDPDU, LLDPTLVType, PortId, TimeToLiveTLV};
     pub use crate::tlv_lldpdu_codec::TLV;
@@ -66,17 +64,84 @@ pub mod artifact_exchange_service {
     pub mod server;
 }
 
-use std::sync::atomic::{AtomicU32, Ordering};
-// ───── Reexports: commonly used components ─────
 pub use cmdu_message_id_generator::MessageIdGenerator;
 pub use cmdu_observer::CMDUObserver;
 pub use ethernet_subject_reception::EthernetReceiver;
 pub use ethernet_subject_transmission::EthernetSender;
 pub use lldpdu_observer::LLDPObserver;
 pub use sdu_codec::SDU;
+use std::future::Future;
+use std::sync::atomic::{AtomicU32, Ordering};
+use tokio::runtime::Handle;
+use tokio::task::{AbortHandle, JoinHandle, JoinSet};
 pub use topology_manager::TopologyDatabase;
+use tracing::{Instrument, Span};
 
 pub fn next_task_id() -> u32 {
     static TASK_ID: AtomicU32 = AtomicU32::new(0);
     TASK_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+#[track_caller]
+pub fn spawn_named<F>(name: impl AsRef<str>, future: F) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name.as_ref())
+        .spawn(future)
+        .expect("runtime is dead")
+}
+
+#[track_caller]
+pub fn spawn_on_named<F>(
+    name: impl AsRef<str>,
+    runtime: &Handle,
+    future: F,
+) -> JoinHandle<F::Output>
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name.as_ref())
+        .spawn_on(future, runtime)
+        .expect("runtime is dead")
+}
+
+#[track_caller]
+pub fn spawn_join_set_named<F>(
+    name: impl AsRef<str>,
+    span: Option<Span>,
+    set: &mut JoinSet<F::Output>,
+    future: F,
+) -> AbortHandle
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    let task = set.build_task().name(name.as_ref());
+    let result = match span {
+        None => task.spawn(future),
+        Some(e) => task.spawn(future.instrument(e)),
+    };
+    result.expect("runtime is dead")
+}
+
+#[track_caller]
+pub fn spawn_join_set_blocking_named<F, T>(
+    name: impl AsRef<str>,
+    set: &mut JoinSet<F::Output>,
+    function: F,
+) -> AbortHandle
+where
+    F: FnOnce() -> T,
+    F: Send + 'static,
+    T: Send + 'static,
+{
+    set.build_task()
+        .name(name.as_ref())
+        .spawn_blocking(function)
+        .expect("runtime is dead")
 }

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -22,7 +22,6 @@
 mod logger;
 
 use clap::{Parser, ValueEnum};
-use ieee1905::CMDUObserver;
 use ieee1905::al_sap::AlServiceAccessPoint;
 use ieee1905::artifact_exchange_service::client::ArtifactExchangeClientFactory;
 use ieee1905::artifact_exchange_service::server::ArtifactExchangeServer;
@@ -35,6 +34,7 @@ use ieee1905::interface_manager::*;
 use ieee1905::lldpdu_observer::LLDPObserver;
 use ieee1905::lldpdu_proxy::lldp_discovery_worker;
 use ieee1905::topology_manager::*;
+use ieee1905::{CMDUObserver, spawn_named};
 use sd_notify::NotifyState;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
@@ -191,12 +191,15 @@ async fn main() -> anyhow::Result<()> {
     let forwarding_interface_clone = forwarding_interface.clone();
 
     // Launch of AL-SAP as independent task
-    tokio::task::spawn(AlServiceAccessPoint::run(
-        sap_control_path,
-        sap_data_path,
-        sender_clone,
-        forwarding_interface_clone,
-    ));
+    spawn_named(
+        "al_sap",
+        AlServiceAccessPoint::run(
+            sap_control_path,
+            sap_data_path,
+            sender_clone,
+            forwarding_interface_clone,
+        ),
+    );
 
     // Initialization of the CMDU handler
     let cmdu_handler = Arc::new(
@@ -244,25 +247,26 @@ async fn main() -> anyhow::Result<()> {
         }
 
         let lldp_sender = EthernetSender::new(&interface.name, Arc::clone(&mutex_tx));
-        tokio::task::spawn(lldp_discovery_worker(
-            lldp_sender,
-            chassis_id,
-            interface.mac,
-            interface.name,
-        ));
+        spawn_named(
+            format!("proxy_lldp_discovery/{}", interface.name),
+            lldp_discovery_worker(lldp_sender, chassis_id, interface.mac, interface.name),
+        );
     }
 
     let discovery_interface_ieee1905 = forwarding_interface.clone();
 
     tracing::debug!("Starting IEEE1905 Discovery on {}", forwarding_interface);
 
-    tokio::task::spawn(cmdu_topology_discovery_transmission_worker(
-        discovery_interface_ieee1905,
-        Arc::clone(&sender),
-        Arc::clone(&message_id_generator),
-        al_mac,
-        forwarding_mac,
-    ));
+    spawn_named(
+        "proxy_topo_discovery",
+        cmdu_topology_discovery_transmission_worker(
+            discovery_interface_ieee1905,
+            sender.clone(),
+            message_id_generator.clone(),
+            al_mac,
+            forwarding_mac,
+        ),
+    );
 
     let mut signal_terminate = signal(SignalKind::terminate())?;
     let mut signal_interrupt = signal(SignalKind::interrupt())?;

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -29,6 +29,7 @@ use crate::{
         CMDUFragmentation, DeviceIdentificationType, Ieee1905ProfileVersion, LinkMetricQuery,
         MediaType, MediaTypeSpecialInfo, Profile2ApCapability, SupportedFreqBand,
     },
+    spawn_named,
 };
 use crate::{
     artifact_exchange_service::client::ArtifactExchangeClientFactory,
@@ -531,8 +532,14 @@ impl TopologyDatabase {
             artifact_exchange_client_factory: Default::default(),
             artifact_exchange_server_ip_address: Default::default(),
         });
-        tokio::spawn(this.clone().refresh_topology_worker());
-        tokio::spawn(this.clone().refresh_interfaces_worker());
+        spawn_named(
+            "db/refresh_topology",
+            this.clone().refresh_topology_worker(),
+        );
+        spawn_named(
+            "db/refresh_interfaces",
+            this.clone().refresh_interfaces_worker(),
+        );
         this
     }
 


### PR DESCRIPTION
1. added name to each task, making it much easier to distinquish them in tokio console
<img width="1483" height="375" alt="image" src="https://github.com/user-attachments/assets/1d452dbf-de54-488c-ba71-98855d88981a" />

2. added macs to log records for each task where it makes sense (making it easier to track which logs are related to which node)
<img width="1387" height="264" alt="image" src="https://github.com/user-attachments/assets/a6c360c9-4e87-4fe2-89fc-06ad61780bdd" />

3. unified `cmdu_proxy.rs` tasks to use `#[instrument]` maco (previously some where using, other not)