### PR TITLE
[#397] add Linux and OVS bridge detection

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,6 @@ linker = "aarch64-linux-gnu-gcc"
 
 [target.aarch64-unknown-linux-musl]
 linker = "aarch64-linux-musl-gcc"
+
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-unknown-linux-musl-gcc"

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Based on the capability of devices to process IEEE1905 CMDU packets we can disti
 The topology construction process in IEEE1905 consists of the following steps:
 
 1. LLDP discovery:
-Before CMDU packet exchange, IEEE1905 will trigger LLDP protocol to discover neighbors with bridging capabilities, and include it as part of the topology graph. LLDPDU's use a link local multicast address being consumed by the platform bridge, such as a Linux bridge or OVS bridge, so in RDK-B use case will not reach the IEEE1905 service.
+Before CMDU packet exchange, IEEE1905 will trigger LLDP protocol to discover neighbors with bridging capabilities, and include it as part of the topology graph. LLDPDUs use a link-local multicast address being consumed by the platform bridge, such as a Linux bridge or OVS bridge, so in the RDK-B use case they will not reach the IEEE1905 service.
 
 2. Topology Discovery Advertisement:
 Each IEEE1905 device periodically broadcasts 1905 Topology Discovery Messages on all its available network interfaces (Wi-Fi, Ethernet, MoCA, PLC).
@@ -525,7 +525,7 @@ By default, the service runs with the topology CLI disabled, info log level, lis
 
 #### Enable topology CLI
 
-By default topology CLI is disabled.
+By default, topology CLI is disabled and requires `topology_ui` feature flag.
 When topology CLI is enabled. Log files are saved to a file and will not appear on standard output.
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ journalctl -u ieee1905.service
 
 ### Service command line arguments
 
-By default service run with topology CLI disabled, info log level, listening on ```eth0``` interface and unix sockets named ```/tmp/al_control_socket``` and ```/tmp/al_data_socket```.
+By default, the service runs with the topology CLI disabled, info log level, listening on `eth0` interface, and Unix sockets named `/tmp/al_control_socket` and `/tmp/al_data_socket`.
 
 #### Enable topology CLI
 
@@ -691,7 +691,7 @@ Change unix sockets to ```ctrl.sock``` and ```data.sock```
 
 #### Change listening interface
 
-Change interface to ```eth1```. IEEE1905 uses this interface to derive the related bridge and filter the local interface list accordingly.
+Change interface to `eth1`. IEEE1905 uses this interface to derive the related bridge and filter the local interface list accordingly.
 
 ```shell
 /usr/bin/ieee1905 -i eth1

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Based on the capability of devices to process IEEE1905 CMDU packets we can disti
 The topology construction process in IEEE1905 consists of the following steps:
 
 1. LLDP discovery:
-Before CMDU packet exchange, IEEE1905 will trigger LLDP protocol to discover neighbors with bridging capabilities, and include it as part of the topology graph. LLDPDU's use a link local multicast address being consumed by the linux bridge so in RDK-B use case will not reach the IEEE1905 service.
+Before CMDU packet exchange, IEEE1905 will trigger LLDP protocol to discover neighbors with bridging capabilities, and include it as part of the topology graph. LLDPDU's use a link local multicast address being consumed by the platform bridge, such as a Linux bridge or OVS bridge, so in RDK-B use case will not reach the IEEE1905 service.
 
 2. Topology Discovery Advertisement:
 Each IEEE1905 device periodically broadcasts 1905 Topology Discovery Messages on all its available network interfaces (Wi-Fi, Ethernet, MoCA, PLC).
@@ -450,7 +450,8 @@ All the logic for the installation and activation has been included into the bui
 ### Managing the Service
 
 You can use this simple systemd unit to launch the ieee1905 service in the
-background:
+background. Set `-i`/`--interface` to the forwarding interface used by the platform;
+IEEE1905 derives the related bridge from this interface during local interface discovery:
 
 ```sh
 
@@ -466,7 +467,7 @@ After=network.target
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/ieee1905
+ExecStart=/usr/bin/ieee1905 -i eth0
 
 [Install]
 WantedBy=multi-user.target
@@ -520,7 +521,7 @@ journalctl -u ieee1905.service
 
 ### Service command line arguments
 
-By default service run with topology CLI enabled, info log level, listening on ```eth0``` interface and unix sockets named ```/tmp/al_control_socket``` and ```/tmp/al_data_socket```.
+By default service run with topology CLI disabled, info log level, listening on ```eth0``` interface and unix sockets named ```/tmp/al_control_socket``` and ```/tmp/al_data_socket```.
 
 #### Enable topology CLI
 
@@ -690,7 +691,7 @@ Change unix sockets to ```ctrl.sock``` and ```data.sock```
 
 #### Change listening interface
 
-Change interface to ```eth1```
+Change interface to ```eth1```. IEEE1905 uses this interface to derive the related bridge and filter the local interface list accordingly.
 
 ```shell
 /usr/bin/ieee1905 -i eth1

--- a/ieee1905-core/Cargo.toml
+++ b/ieee1905-core/Cargo.toml
@@ -20,7 +20,7 @@ rbus-provider = { path = "../rbus-provider", optional = true }
 pnet = "0.35.0"
 netdev = "0.45.0"
 nom = "8.0.0"
-tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "sync", "time", "signal", "fs"] }
+tokio = { version = "1.48.0", features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "sync", "time", "signal", "fs", "process"] }
 console-subscriber = { version = "0.5.0", optional = true }
 async-trait = "0.1.89"
 tracing = { version = "0.1", features = ["release_max_level_debug"] }

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -1033,7 +1033,7 @@ mod tests {
     use crate::cmdu_codec::tests::make_dummy_cmdu;
     use crate::cmdu_message_id_generator::get_message_id_generator;
     use crate::cmdu_reassembler::CmduReassemblyError;
-    use crate::interface_manager::get_forwarding_interface_name;
+    use crate::interface_manager::get_interface_info;
     use crate::interface_manager::get_local_al_mac;
     use tokio::sync::Mutex;
 
@@ -1294,14 +1294,12 @@ mod tests {
     async fn test_handle_cmdu_function_for_oversized_cmdu() {
         // Prepare forwarding interface
         let interface_name = "eth0".to_string();
-        let forwarding_interface =
-            if let Some(iface) = get_forwarding_interface_name(interface_name.clone()) {
-                tracing::info!("Forwarding interface: {}", iface);
-                iface
-            } else {
-                tracing::debug!("No Ethernet interface found for forwarding, using default.");
-                "eth_default".to_string() // Default interface name if none found
-            };
+        let Some(forwarding_interface) = get_interface_info(&interface_name) else {
+            panic!("No Ethernet interface found for forwarding");
+        };
+
+        let forwarding_interface = &forwarding_interface.if_name;
+        tracing::info!("Forwarding interface: {forwarding_interface}");
 
         // Prepare sender
         let mutex_tx = Arc::new(Mutex::new(()));

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -184,50 +184,11 @@ async fn filter_interfaces_by_bridge(
     if filter_interfaces_by_ovs_bridge(forwarding_if_name, links).await {
         return;
     }
-
-    let Some(interface) = links.values().find(|e| e.if_name == forwarding_if_name) else {
-        return warn!("forwarding interface {forwarding_if_name:?} not found, filtering skipped");
-    };
-
-    let forwarding_bridge_if_index = match interface.link_kind.as_deref() {
-        Some("bridge") => {
-            debug!("forwarding interface {forwarding_if_name:?} is a bridge, filtering by it");
-            interface.if_index as u32
-        }
-        Some("veth") if interface.bridge_if_index.is_none() => {
-            let Some(pair_index) = interface.link_if_index else {
-                return warn!("veth interface {} doesn't have a pair", interface.if_name);
-            };
-            let Some(pair_interface) = links.get(&pair_index) else {
-                return warn!("veth interface {} pair not found", interface.if_name);
-            };
-            let Some(pair_bridge_if_index) = pair_interface.bridge_if_index else {
-                return;
-            };
-            let Some(pair_bridge) = links.get(&(pair_bridge_if_index as i32)) else {
-                return warn!("cannot find bridge interface {pair_bridge_if_index}");
-            };
-            if pair_bridge.link_kind.as_deref() != Some("bridge") {
-                return warn!("interface {:?} is not a bridge", pair_bridge.if_name);
-            }
-
-            debug!(
-                "forwarding interface {forwarding_if_name:?} is a veth, filtering by its bridge {:?}",
-                pair_bridge.if_name,
-            );
-            pair_bridge_if_index
-        }
-        _ => {
-            let Some(bridge_if_index) = interface.bridge_if_index else {
-                return;
-            };
-
-            debug!("forwarding interface {forwarding_if_name:?} has a bridge, filtering by it");
-            bridge_if_index
-        }
-    };
-
-    links.retain(|_, e| e.bridge_if_index == Some(forwarding_bridge_if_index));
+    if filter_interfaces_by_linux_bridge(forwarding_if_name, links) {
+        return;
+    }
+    debug!("forwarding interface has not bridge, removing others");
+    links.retain(|_, e| e.if_name == forwarding_if_name);
 }
 
 async fn filter_interfaces_by_ovs_bridge(
@@ -262,6 +223,41 @@ async fn filter_interfaces_by_ovs_bridge(
 
     debug!("filtering interfaces by {bridge:?} ovs bridge");
     links.retain(|_, e| interfaces.contains(&e.if_name));
+    true
+}
+
+fn filter_interfaces_by_linux_bridge(
+    forwarding_if_name: &str,
+    links: &mut IndexMap<i32, LinkInterfaceInfo>,
+) -> bool {
+    let Some(mut interface) = links.values().find(|e| e.if_name == forwarding_if_name) else {
+        warn!("forwarding interface {forwarding_if_name:?} not found, filtering skipped");
+        return false;
+    };
+
+    // select other veth pair endpoint if current endpoint is not connected to the bridge
+    if interface.link_kind.as_deref() == Some("veth")
+        && interface.bridge_if_index.is_none()
+        && let Some(pair_if_index) = interface.link_if_index
+        && let Some(pair_interface) = links.get(&pair_if_index)
+    {
+        interface = pair_interface;
+    }
+
+    // find interface bridge
+    let bridge = if interface.link_kind.as_deref() == Some("bridge") {
+        interface
+    } else if let Some(bridge_if_index) = interface.bridge_if_index
+        && let Some(bridge) = links.get(&(bridge_if_index as i32))
+    {
+        bridge
+    } else {
+        return false;
+    };
+
+    debug!("filtering interfaces by {:?} Linux bridge", bridge.if_name);
+    let bridge_if_index = bridge.if_index as u32;
+    links.retain(|_, e| e.bridge_if_index == Some(bridge_if_index));
     true
 }
 

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -140,7 +140,7 @@ pub async fn get_interfaces(
     // filter out interfaces that are not bridged with the forwarding interfaces
     filter_interfaces_by_bridge(forwarding_if_name, &mut links).await;
 
-    // filter out all virtual interfaces
+    // filter out veth (virtual) interfaces
     links.retain(|_, e| e.link_kind.as_deref() != Some("veth"));
 
     match get_wireless_interfaces(&mut links).await {
@@ -1026,7 +1026,7 @@ async fn call_ovs_list_bridge_interfaces(bridge_name: &str) -> anyhow::Result<In
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("ovs-vsctl list-ports failed: {stderr}");
+        anyhow::bail!("ovs-vsctl list-ifaces {bridge_name} failed: {stderr}");
     }
 
     let result = String::from_utf8_lossy(&output.stdout)

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -81,11 +81,11 @@ pub fn get_local_al_mac(interface_name: String) -> Option<MacAddr> {
 
 pub fn get_interface_info(if_name: &str) -> Option<InterfaceInfo> {
     let interfaces = datalink::interfaces();
-    let interface = interfaces.iter().find(|e| e.name == if_name)?;
+    let interface = interfaces.into_iter().find(|e| e.name == if_name)?;
     Some(InterfaceInfo {
         mac: interface.mac?,
         if_index: interface.index,
-        if_name: if_name.to_string(),
+        if_name: interface.name,
     })
 }
 
@@ -105,18 +105,6 @@ pub fn get_forwarding_interface_mac(interface_name: &str) -> MacAddr {
         tracing::debug!("No Ethernet interface found for forwarding, using default.");
         MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
     }
-}
-
-/// **Returns `Some(String)` if found, otherwise `None`.**
-pub fn get_forwarding_interface_name(interface_name: String) -> Option<String> {
-    // Fetch all network interfaces
-    let interfaces = datalink::interfaces();
-
-    // Find the first Ethernet interface (`ethX`) and return its name
-    interfaces
-        .iter()
-        .find(|iface| iface.name.starts_with(&interface_name))
-        .map(|iface| iface.name.clone()) // Extract and return interface name
 }
 
 /// **Gets the MAC address of a given network interface**
@@ -187,7 +175,7 @@ async fn filter_interfaces_by_bridge(
     if filter_interfaces_by_linux_bridge(forwarding_if_name, links) {
         return;
     }
-    debug!("forwarding interface has not bridge, removing others");
+    debug!("forwarding interface has no bridge, removing others");
     links.retain(|_, e| e.if_name == forwarding_if_name);
 }
 
@@ -998,7 +986,7 @@ async fn call_ovs_interface_to_bridge(if_name: &str) -> anyhow::Result<String> {
     debug!("ovs-vsctl iface-to-br {if_name}");
 
     let output = tokio::process::Command::new("ovs-vsctl")
-        .args(["--timeout=5", "iface-to-br", if_name])
+        .args(["--timeout=5", "--", "iface-to-br", if_name])
         .output()
         .await?;
 
@@ -1016,7 +1004,7 @@ async fn call_ovs_list_bridge_interfaces(bridge_name: &str) -> anyhow::Result<In
     debug!("ovs-vsctl list-ifaces {bridge_name}");
 
     let output = tokio::process::Command::new("ovs-vsctl")
-        .args(["--timeout=5", "list-ifaces", bridge_name])
+        .args(["--timeout=5", "--", "list-ifaces", bridge_name])
         .output()
         .await?;
 

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -55,7 +55,7 @@ use neli::socket::asynchronous::NlSocketHandle;
 use neli::types::{GenlBuffer, RtBuffer};
 use neli::utils::Groups;
 use std::ops::{BitAnd, Div};
-use tracing::{error, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 #[derive(Debug, Clone)]
 pub struct InterfaceInfo {
@@ -131,9 +131,17 @@ pub fn get_mac_address_by_interface(interface_name: &str) -> Option<MacAddr> {
         .and_then(|iface| iface.mac) // Extract MAC address if found
 }
 
-pub async fn get_interfaces() -> anyhow::Result<Vec<Ieee1905LocalInterface>> {
+pub async fn get_interfaces(
+    forwarding_if_name: &str,
+) -> anyhow::Result<Vec<Ieee1905LocalInterface>> {
     let mut interfaces = Vec::new();
     let mut links = get_link_interfaces().await?;
+
+    // filter out interfaces that are not bridged with the forwarding interfaces
+    filter_interfaces_by_bridge(forwarding_if_name, &mut links).await;
+
+    // filter out all virtual interfaces
+    links.retain(|_, e| e.link_kind.as_deref() != Some("veth"));
 
     match get_wireless_interfaces(&mut links).await {
         Ok(e) => interfaces.extend(e),
@@ -166,13 +174,95 @@ async fn get_link_interfaces() -> anyhow::Result<IndexMap<i32, LinkInterfaceInfo
             }
         }
     }
-
-    // remove interfaces that are not part of the bridge
-    if let Some(interface) = links.values().find(|e| e.if_name == "brlan0") {
-        let bridge_if_index = interface.if_index;
-        links.retain(|_, e| e.bridge_if_index == Some(bridge_if_index as u32));
-    }
     Ok(links)
+}
+
+async fn filter_interfaces_by_bridge(
+    forwarding_if_name: &str,
+    links: &mut IndexMap<i32, LinkInterfaceInfo>,
+) {
+    if filter_interfaces_by_ovs_bridge(forwarding_if_name, links).await {
+        return;
+    }
+
+    let Some(interface) = links.values().find(|e| e.if_name == forwarding_if_name) else {
+        return warn!("forwarding interface {forwarding_if_name:?} not found, filtering skipped");
+    };
+
+    let forwarding_bridge_if_index = match interface.link_kind.as_deref() {
+        Some("bridge") => {
+            debug!("forwarding interface {forwarding_if_name:?} is a bridge, filtering by it");
+            interface.if_index as u32
+        }
+        Some("veth") if interface.bridge_if_index.is_none() => {
+            let Some(pair_index) = interface.link_if_index else {
+                return warn!("veth interface {} doesn't have a pair", interface.if_name);
+            };
+            let Some(pair_interface) = links.get(&pair_index) else {
+                return warn!("veth interface {} pair not found", interface.if_name);
+            };
+            let Some(pair_bridge_if_index) = pair_interface.bridge_if_index else {
+                return;
+            };
+            let Some(pair_bridge) = links.get(&(pair_bridge_if_index as i32)) else {
+                return warn!("cannot find bridge interface {pair_bridge_if_index}");
+            };
+            if pair_bridge.link_kind.as_deref() != Some("bridge") {
+                return warn!("interface {:?} is not a bridge", pair_bridge.if_name);
+            }
+
+            debug!(
+                "forwarding interface {forwarding_if_name:?} is a veth, filtering by its bridge {:?}",
+                pair_bridge.if_name,
+            );
+            pair_bridge_if_index
+        }
+        _ => {
+            let Some(bridge_if_index) = interface.bridge_if_index else {
+                return;
+            };
+
+            debug!("forwarding interface {forwarding_if_name:?} has a bridge, filtering by it");
+            bridge_if_index
+        }
+    };
+
+    links.retain(|_, e| e.bridge_if_index == Some(forwarding_bridge_if_index));
+}
+
+async fn filter_interfaces_by_ovs_bridge(
+    mut forwarding_if_name: &str,
+    links: &mut IndexMap<i32, LinkInterfaceInfo>,
+) -> bool {
+    // select other veth pair endpoint if current endpoint is not connected to the bridge
+    if let Some(forwarding_interface) = links.values().find(|e| e.if_name == forwarding_if_name)
+        && forwarding_interface.link_kind.as_deref() == Some("veth")
+        && forwarding_interface.bridge_if_index.is_none()
+        && let Some(pair_if_index) = forwarding_interface.link_if_index
+        && let Some(pair_interface) = links.get(&pair_if_index)
+    {
+        forwarding_if_name = pair_interface.if_name.as_str();
+    }
+
+    let bridge = match call_ovs_interface_to_bridge(forwarding_if_name).await {
+        Ok(e) => e,
+        Err(e) => {
+            debug!(%e, "ovs bridge not available");
+            return false;
+        }
+    };
+
+    let interfaces = match call_ovs_list_bridge_interfaces(&bridge).await {
+        Ok(e) => e,
+        Err(e) => {
+            error!(bridge, %e, "call_ovs_list_bridge_interfaces failed");
+            return false;
+        }
+    };
+
+    debug!("filtering interfaces by {bridge:?} ovs bridge");
+    links.retain(|_, e| interfaces.contains(&e.if_name));
+    true
 }
 
 #[derive(Debug)]
@@ -181,6 +271,8 @@ struct LinkInterfaceInfo {
     if_index: i32,
     if_name: String,
     if_flags: Iff,
+    link_kind: Option<String>,
+    link_if_index: Option<i32>,
     bridge_if_index: Option<u32>,
     vlan_id: Option<u16>,
     link_stats: Option<RtnlLinkStats64>,
@@ -220,28 +312,40 @@ async fn call_rt_get_links() -> anyhow::Result<IndexMap<i32, LinkInterfaceInfo>>
         };
 
         let mut vlan_id = None;
-        if let Ok(link_info) = attr_handle.get_nested_attributes(Ifla::Linkinfo) {
-            match link_info.get_attr_payload_as_with_len_borrowed::<&[u8]>(IflaInfo::Kind) {
-                Ok(b"veth\0") => continue,
-                Ok(b"vlan\0") => {
-                    if let Ok(data) = link_info.get_nested_attributes(IflaInfo::Data) {
-                        vlan_id = data.get_attr_payload_as(IflaVlan::Id).ok();
-                    }
-                }
-                _ => {}
+        let mut link_kind = None;
+        if let Ok(link_info) = attr_handle.get_nested_attributes(Ifla::Linkinfo)
+            && let Ok(kind) = link_info.get_attr_payload_as_with_len::<String>(IflaInfo::Kind)
+        {
+            link_kind = Some(kind.clone()).filter(|s| !s.is_empty());
+
+            if kind.as_str() == "vlan"
+                && let Ok(data) = link_info.get_nested_attributes(IflaInfo::Data)
+            {
+                vlan_id = data.get_attr_payload_as(IflaVlan::Id).ok();
             }
         }
 
         let if_flags = *payload.ifi_flags();
         let if_index = *payload.ifi_index();
+        let link_if_index = attr_handle.get_attr_payload_as(Ifla::Link).ok();
         let bridge_if_index = attr_handle.get_attr_payload_as(Ifla::Master).ok();
         let link_stats = get_link_stats(&attr_handle);
+        trace!(
+            if_name = %if_name,
+            if_index,
+            ?link_kind,
+            ?link_if_index,
+            ?bridge_if_index,
+            "parsed link interface",
+        );
 
         let interface_info = LinkInterfaceInfo {
             mac: MacAddr::from(mac),
             if_index,
             if_name,
             if_flags,
+            link_kind,
+            link_if_index,
             bridge_if_index,
             vlan_id,
             link_stats,
@@ -891,6 +995,48 @@ async fn call_netdev_get_ethernet_interfaces() -> anyhow::Result<Vec<EthernetInt
             is_802_3ab_supported: true,
         });
     }
+    Ok(result)
+}
+
+async fn call_ovs_interface_to_bridge(if_name: &str) -> anyhow::Result<String> {
+    debug!("ovs-vsctl iface-to-br {if_name}");
+
+    let output = tokio::process::Command::new("ovs-vsctl")
+        .args(["--timeout=5", "iface-to-br", if_name])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("ovs-vsctl iface-to-br {if_name} failed: {stderr}");
+    }
+
+    let result = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    debug!("ovs-vsctl iface-to-br {if_name} -> {result:?}");
+    Ok(result)
+}
+
+async fn call_ovs_list_bridge_interfaces(bridge_name: &str) -> anyhow::Result<IndexSet<String>> {
+    debug!("ovs-vsctl list-ifaces {bridge_name}");
+
+    let output = tokio::process::Command::new("ovs-vsctl")
+        .args(["--timeout=5", "list-ifaces", bridge_name])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("ovs-vsctl list-ports failed: {stderr}");
+    }
+
+    let result = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect();
+
+    debug!("ovs-vsctl list-ifaces {bridge_name} -> {result:?}");
     Ok(result)
 }
 

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -234,7 +234,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Sart of the discovery process
 
-    for interface in get_lldp_compatible_interfaces().await {
+    for interface in get_lldp_compatible_interfaces(&cli.interface).await {
         tracing::info!(
             no_receiver = cli.no_lldp_receivers,
             "Starting LLDP Discovery on {}/{}",
@@ -297,16 +297,8 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn get_lldp_compatible_interfaces() -> Vec<Ieee1905LocalInterface> {
-    let mut interfaces = get_interfaces().await.unwrap_or_default();
-
-    if let Some(bridge) = interfaces
-        .iter()
-        .find(|e| e.name.eq_ignore_ascii_case("brlan0"))
-    {
-        let bridge_index = bridge.index.cast_unsigned();
-        interfaces.retain(|e| e.bridging_tuple == Some(bridge_index));
-    }
+async fn get_lldp_compatible_interfaces(interface_name: &str) -> Vec<Ieee1905LocalInterface> {
+    let mut interfaces = get_interfaces(interface_name).await.unwrap_or_default();
 
     interfaces.retain(|e| e.media_type.is_ethernet());
     interfaces

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -123,8 +123,8 @@ async fn main() -> anyhow::Result<()> {
         };
 
     // Calculate AL MAC Address (Derived from Forwarding Ethernet Interface)
-    let Some(if_info) = get_interface_info(&cli.interface) else {
-        anyhow::bail!("failed to get local interface {}", cli.interface);
+    let Some(if_info) = get_interface_info(&forwarding_interface) else {
+        anyhow::bail!("failed to get local interface {}", forwarding_interface);
     };
 
     let al_mac = if_info.mac;
@@ -132,7 +132,7 @@ async fn main() -> anyhow::Result<()> {
 
     // // Initialize Database
 
-    let topology_db = TopologyDatabase::get_instance(al_mac, &cli.interface);
+    let topology_db = TopologyDatabase::get_instance(al_mac, &forwarding_interface);
 
     // Upon every loop restart topology database role can change
     topology_db.set_local_role(None).await;
@@ -218,7 +218,7 @@ async fn main() -> anyhow::Result<()> {
     let cmdu_observer = CMDUObserver::new(Arc::clone(&cmdu_handler));
     // FLAG to enable and disable LLDP
     // Initialize LLDP Observer with chassis_id assuming al_mac an chassis id have the same value as idicated in IEEE1905
-    let lldp_observer = LLDPObserver::new(chassis_id, cli.interface.clone());
+    let lldp_observer = LLDPObserver::new(chassis_id, forwarding_interface.clone());
 
     tracing::info!("LLDP and CMDU observers initilized with local MAC: {al_mac}");
 
@@ -234,7 +234,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Sart of the discovery process
 
-    for interface in get_lldp_compatible_interfaces(&cli.interface).await {
+    for interface in get_lldp_compatible_interfaces(&forwarding_interface).await {
         tracing::info!(
             no_receiver = cli.no_lldp_receivers,
             "Starting LLDP Discovery on {}/{}",

--- a/ieee1905-core/src/main.rs
+++ b/ieee1905-core/src/main.rs
@@ -112,20 +112,12 @@ async fn main() -> anyhow::Result<()> {
 
     let mut join_sets = Vec::new();
 
-    //Set AL MAC & test MAC addresses
-    let forwarding_interface =
-        if let Some(iface) = get_forwarding_interface_name(cli.interface.clone()) {
-            tracing::info!("Forwarding interface: {}", iface);
-            iface
-        } else {
-            tracing::debug!("No Ethernet interface found for forwarding, using default.");
-            "eth_default".to_string() // Default interface name if none found
-        };
-
-    // Calculate AL MAC Address (Derived from Forwarding Ethernet Interface)
-    let Some(if_info) = get_interface_info(&forwarding_interface) else {
-        anyhow::bail!("failed to get local interface {}", forwarding_interface);
+    let Some(if_info) = get_interface_info(&cli.interface) else {
+        anyhow::bail!("failed to get local interface {}", cli.interface);
     };
+
+    let forwarding_interface = if_info.if_name.clone();
+    tracing::info!("Forwarding interface: {forwarding_interface}");
 
     let al_mac = if_info.mac;
     tracing::info!("AL MAC address: {}", al_mac);

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -734,7 +734,7 @@ impl TopologyDatabase {
         loop {
             interval.tick().await;
 
-            match get_interfaces().await {
+            match get_interfaces(&self.interface_name).await {
                 Ok(mut interfaces) => {
                     Self::update_local_neighbours_ieee1905_compatibility(
                         &mut interfaces,


### PR DESCRIPTION
Bridge detection is now based on the configured forwarding interface.
The interface manager first gathers interface metadata from rtnetlink, including link kind, peer link index, and `IFLA_MASTER`.

For OVS-backed setups, it resolves the forwarding interface to an OVS bridge using `ovs-vsctl iface-to-br`, then filters local interfaces using `ovs-vsctl list-ifaces`.

For Linux bridge setups, it derives the bridge from netlink:
- if the forwarding interface is itself a bridge, its own ifindex is used;
- if it is a `veth` without a direct bridge master, the peer endpoint is resolved and its bridge master is used;
- otherwise the forwarding interface `IFLA_MASTER` is used.

After the bridge is resolved, only interfaces that belong to that bridge are kept.