### PR TITLE
[#406] TR-181 v2-21 - Add `Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.IPv4Address/IPv6Address`

### DIFF
--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -304,7 +304,7 @@ impl TLVTrait for MacAddress {
     }
 }
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ipv4 {
     pub entries: Vec<Ipv4Entry>,
 }
@@ -328,7 +328,7 @@ impl TLVTrait for Ipv4 {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ipv4Entry {
     pub mac: MacAddr,
     pub addresses: Vec<Ipv4Address>,
@@ -353,7 +353,7 @@ impl Ipv4Entry {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ipv4Address {
     pub kind: IPv4AddressType,
     pub address: Ipv4Addr,
@@ -386,7 +386,7 @@ impl Ipv4Address {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IPv4AddressType {
     Unknown,
     DHCP,
@@ -483,11 +483,11 @@ impl Ipv6AddressEntry {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ipv6Entry {
     pub mac_address: MacAddr,
     pub link_local_address: Ipv6Addr,
-    pub other_addresses: Vec<Ipv6AddressEntry>,
+    pub routable_addresses: Vec<Ipv6AddressEntry>,
 }
 
 impl Ipv6Entry {
@@ -500,24 +500,24 @@ impl Ipv6Entry {
         let this = Self {
             mac_address,
             link_local_address,
-            other_addresses: other,
+            routable_addresses: other,
         };
 
         Ok((input, this))
     }
 
     fn serialize(&self) -> Vec<u8> {
-        let mut vec = Vec::with_capacity(23 + self.other_addresses.len() * 33);
+        let mut vec = Vec::with_capacity(23 + self.routable_addresses.len() * 33);
         vec.extend(&self.mac_address.octets());
         vec.extend(&self.link_local_address.octets());
-        vec.extend((self.other_addresses.len() as u8).to_be_bytes());
-        vec.extend(self.other_addresses.iter().flat_map(|e| e.serialize()));
+        vec.extend((self.routable_addresses.len() as u8).to_be_bytes());
+        vec.extend(self.routable_addresses.iter().flat_map(|e| e.serialize()));
         vec
     }
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Ipv6 {
     pub entries: Vec<Ipv6Entry>,
 }
@@ -3695,7 +3695,7 @@ pub mod tests {
             entries: vec![Ipv6Entry {
                 mac_address: MacAddr::new(0x02, 0x42, 0xc0, 0xa8, 0x64, 0x02),
                 link_local_address: Ipv6Addr::new(0xfe80, 0, 0, 0, 0x0042, 0xc0ff, 0xfea8, 0x6402),
-                other_addresses: vec![Ipv6AddressEntry {
+                routable_addresses: vec![Ipv6AddressEntry {
                     address_type: IPv6AddressType::SLAAC,
                     ipv6_address: Ipv6Addr::new(0x2001, 0x0db8, 0, 1, 0, 0, 0, 1),
                     ipv6_originator: Ipv6Addr::new(0x2001, 0x0db8, 0, 2, 0, 0, 0, 1),

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -921,16 +921,18 @@ impl CMDUHandler {
             return true;
         };
 
-        let Some(device_identification) = DeviceIdentificationType::find(tlvs) else {
+        let Some(device) = DeviceIdentificationType::find(tlvs) else {
             error!("HigherLayerResponse CMDU missing DeviceIdentificationType TLV");
             return true;
         };
 
         let al_mac = al_mac.al_mac_address;
         let control_url = ControlUrl::find(tlvs);
+        let ipv4 = Ipv4::find(tlvs);
+        let ipv6 = Ipv6::find(tlvs);
 
         let result = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
-            .handle_higher_layer_response(al_mac, message_id, device_identification, control_url)
+            .handle_higher_layer_response(al_mac, message_id, device, control_url, ipv4, ipv6)
             .await;
 
         info!(source = %source_mac, "HigherLayerResponse Processed");

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -787,6 +787,13 @@ pub async fn cmdu_higher_layer_response_transmission(
         TLV::from(ControlUrl {
             url: ArtifactExchangeServer::format_base_url(server_address),
         }),
+        TLV::from(Ipv6 {
+            entries: vec![Ipv6Entry {
+                mac_address: local_al_mac_address,
+                link_local_address: server_address,
+                routable_addresses: vec![],
+            }],
+        }),
         TLV::from(EndOfMessage),
     ];
 

--- a/ieee1905-core/src/rbus.rs
+++ b/ieee1905-core/src/rbus.rs
@@ -12,6 +12,8 @@ use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingT
 use crate::rbus::nt_device_bridge_list::RBus_NetworkTopology_Ieee1905Device_BridgingTuple_InterfaceList;
 use crate::rbus::nt_device_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor;
 use crate::rbus::nt_device_ieee1905_neighbor_metric::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric;
+use crate::rbus::nt_device_ipv4::RBus_NetworkTopology_Ieee1905Device_IPv4;
+use crate::rbus::nt_device_ipv6::RBus_NetworkTopology_Ieee1905Device_IPv6;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use anyhow::bail;
 use rbus_core::{RBusError, RBusLibrary, RBusLogHandler, RBusLogLevel, RBusLogRecord};
@@ -33,6 +35,8 @@ mod nt_device_bridge;
 mod nt_device_bridge_list;
 mod nt_device_ieee1905_neighbor;
 mod nt_device_ieee1905_neighbor_metric;
+mod nt_device_ipv4;
+mod nt_device_ipv6;
 mod nt_device_non_ieee1905_neighbor;
 
 ///
@@ -111,39 +115,65 @@ impl RBusConnection {
             rbus_object("NetworkTopology", (
                 rbus_property("IEEE1905DeviceNumberOfEntries", RBus_NetworkTopology),
                 rbus_table("IEEE1905Device", RBus_NetworkTopology_Ieee1905Device, (
-                    rbus_property("IEEE1905Id", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_property("Version", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_property("RegistrarFreqBand", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_property("FriendlyName", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_property("ManufacturerName", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_property("ManufacturerModel", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_property("BridgingTupleNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_table("BridgingTuple", RBus_NetworkTopology_Ieee1905Device_BridgingTuple, (
-                        rbus_property("InterfaceList", RBus_NetworkTopology_Ieee1905Device_BridgingTuple_InterfaceList),
-                    )),
-                    rbus_property("NonIEEE1905NeighborNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_table("NonIEEE1905Neighbor", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor, (
-                        rbus_property("LocalInterface", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor),
-                        rbus_property("NeighborInterfaceId", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor),
-                    )),
-                    rbus_property("IEEE1905NeighborNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
-                    rbus_table("IEEE1905Neighbor", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor, (
-                        rbus_property("LocalInterface", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
-                        rbus_property("NeighborDeviceId", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
-                        rbus_property("MetricNumberOfEntries", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
-                        rbus_table("Metric", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric, (
-                            rbus_property("NeighborMACAddress", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("IEEE802dot1Bridge", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("PacketErrors", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("PacketErrorsReceived", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("TransmittedPackets", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("PacketsReceived", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("MACThroughputCapacity", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("LinkAvailability", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("PHYRate", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
-                            rbus_property("RSSI", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                    (
+                        rbus_property("IEEE1905Id", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_property("Version", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_property("RegistrarFreqBand", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_property("FriendlyName", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_property("ManufacturerName", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_property("ManufacturerModel", RBus_NetworkTopology_Ieee1905Device),
+                    ),
+                    (
+                        rbus_property("BridgingTupleNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_table("BridgingTuple", RBus_NetworkTopology_Ieee1905Device_BridgingTuple, (
+                            rbus_property("InterfaceList", RBus_NetworkTopology_Ieee1905Device_BridgingTuple_InterfaceList),
                         )),
-                    )),
+                    ),
+                    (
+                        rbus_property("IEEE1905NeighborNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_table("IEEE1905Neighbor", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor, (
+                            rbus_property("LocalInterface", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
+                            rbus_property("NeighborDeviceId", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
+                            rbus_property("MetricNumberOfEntries", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
+                            rbus_table("Metric", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric, (
+                                rbus_property("NeighborMACAddress", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("IEEE802dot1Bridge", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("PacketErrors", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("PacketErrorsReceived", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("TransmittedPackets", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("PacketsReceived", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("MACThroughputCapacity", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("LinkAvailability", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("PHYRate", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                                rbus_property("RSSI", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            )),
+                        )),
+                    ),
+                    (
+                        rbus_property("NonIEEE1905NeighborNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_table("NonIEEE1905Neighbor", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor, (
+                            rbus_property("LocalInterface", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor),
+                            rbus_property("NeighborInterfaceId", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor),
+                        )),
+                    ),
+                    (
+                        rbus_property("IPv4AddressNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_table("IPv4Address", RBus_NetworkTopology_Ieee1905Device_IPv4, (
+                            rbus_property("MACAddress", RBus_NetworkTopology_Ieee1905Device_IPv4),
+                            rbus_property("IPv4Address", RBus_NetworkTopology_Ieee1905Device_IPv4),
+                            rbus_property("IPv4AddressType", RBus_NetworkTopology_Ieee1905Device_IPv4),
+                            rbus_property("DHCPServer", RBus_NetworkTopology_Ieee1905Device_IPv4),
+                        )),
+                    ),
+                    (
+                        rbus_property("IPv6AddressNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_table("IPv6Address", RBus_NetworkTopology_Ieee1905Device_IPv6, (
+                            rbus_property("MACAddress", RBus_NetworkTopology_Ieee1905Device_IPv6),
+                            rbus_property("IPv6Address", RBus_NetworkTopology_Ieee1905Device_IPv6),
+                            rbus_property("IPv6AddressType", RBus_NetworkTopology_Ieee1905Device_IPv6),
+                            rbus_property("IPv6AddressOrigin", RBus_NetworkTopology_Ieee1905Device_IPv6),
+                        )),
+                    ),
                 )),
             )),
         )

--- a/ieee1905-core/src/rbus/nt_device.rs
+++ b/ieee1905-core/src/rbus/nt_device.rs
@@ -1,7 +1,11 @@
 use crate::TopologyDatabase;
-use crate::cmdu_codec::{DeviceIdentificationType, Ieee1905ProfileVersion, SupportedFreqBand};
+use crate::cmdu_codec::{
+    DeviceIdentificationType, Ieee1905ProfileVersion, Ipv4, Ipv6, Ipv6Entry, SupportedFreqBand,
+};
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
 use crate::rbus::nt_device_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor;
+use crate::rbus::nt_device_ipv4::RBus_NetworkTopology_Ieee1905Device_IPv4;
+use crate::rbus::nt_device_ipv6::RBus_NetworkTopology_Ieee1905Device_IPv6;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use crate::rbus::peek_topology_database;
 use crate::topology_manager::{
@@ -26,6 +30,8 @@ use tokio::sync::RwLockReadGuard;
 /// - BridgingTupleNumberOfEntries
 /// - IEEE1905NeighborNumberOfEntries
 /// - NonIEEE1905NeighborNumberOfEntries
+/// - IPv4AddressNumberOfEntries
+/// - IPv6AddressNumberOfEntries
 ///
 pub struct RBus_NetworkTopology_Ieee1905Device;
 
@@ -60,9 +66,7 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
                         let mac = db.local_mac.blocking_read();
                         format!("{mac}-local")
                     }
-                    RBus_Ieee1905Device_Node::Remote(e) => {
-                        e.device_data.al_mac.to_string()
-                    }
+                    RBus_Ieee1905Device_Node::Remote(e) => e.device_data.al_mac.to_string(),
                 };
                 args.property.set(&al_mac_str);
                 Ok(())
@@ -124,6 +128,16 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
             b"NonIEEE1905NeighborNumberOfEntries" => {
                 let iter = RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor::iter(&node);
                 args.property.set(&(iter.count() as u32));
+                Ok(())
+            }
+            b"IPv4AddressNumberOfEntries" => {
+                let pairs = RBus_NetworkTopology_Ieee1905Device_IPv4::iter(&node);
+                args.property.set(&(pairs.count() as u32));
+                Ok(())
+            }
+            b"IPv6AddressNumberOfEntries" => {
+                let pairs = RBus_NetworkTopology_Ieee1905Device_IPv6::iter(&node);
+                args.property.set(&(pairs.count() as u32));
                 Ok(())
             }
             _ => Err(RBusError::ElementDoesNotExists),
@@ -188,6 +202,30 @@ impl<'a> RBus_Ieee1905Device_Node<'a> {
                 let ifs = e.device_data.local_interface_list.as_deref();
                 Either::Right(ifs.unwrap_or_default().iter())
             }
+        }
+    }
+
+    pub fn ipv4_addresses(&self) -> Option<&Ipv4> {
+        match self {
+            RBus_Ieee1905Device_Node::Local(_) => None,
+            RBus_Ieee1905Device_Node::Remote(e) => e.device_data.ipv4.as_ref(),
+        }
+    }
+
+    pub fn ipv6_addresses(&self) -> Option<Ipv6> {
+        match self {
+            RBus_Ieee1905Device_Node::Local(_) => {
+                let db = peek_topology_database().ok()?;
+                let address = db.get_artifact_exchange_server_ip_address()?;
+                Some(Ipv6 {
+                    entries: vec![Ipv6Entry {
+                        mac_address: db.al_mac_address,
+                        link_local_address: address,
+                        routable_addresses: vec![],
+                    }],
+                })
+            }
+            RBus_Ieee1905Device_Node::Remote(e) => e.device_data.ipv6.clone(),
         }
     }
 }

--- a/ieee1905-core/src/rbus/nt_device_ipv4.rs
+++ b/ieee1905-core/src/rbus/nt_device_ipv4.rs
@@ -1,0 +1,83 @@
+use crate::cmdu_codec::{IPv4AddressType, Ipv4Address};
+use crate::rbus::nt_device::RBus_Ieee1905Device_Node;
+use crate::rbus::peek_topology_database;
+use nom::AsBytes;
+use pnet::datalink::MacAddr;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+
+///
+/// Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.IPv4Address.{i}.
+/// - MACAddress
+/// - IPv4Address
+/// - IPv4AddressType
+/// - DHCPServer
+///
+pub struct RBus_NetworkTopology_Ieee1905Device_IPv4;
+
+impl RBus_NetworkTopology_Ieee1905Device_IPv4 {
+    pub fn iter<'a>(
+        node: &'a RBus_Ieee1905Device_Node,
+    ) -> impl Iterator<Item = (MacAddr, &'a Ipv4Address)> {
+        node.ipv4_addresses()
+            .into_iter()
+            .flat_map(|e| e.entries.iter())
+            .flat_map(|e| {
+                let mac = e.mac;
+                e.addresses.iter().map(move |address| (mac, address))
+            })
+    }
+}
+
+impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device_IPv4 {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+        Ok(Self::iter(&node).count() as u32)
+    }
+}
+
+impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_IPv4 {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let Some(address_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+        let Some((mac, ipv4)) = Self::iter(&node).nth(address_index as usize) else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        match args.path_name.as_bytes() {
+            b"MACAddress" => {
+                args.property.set(&mac.to_string());
+                Ok(())
+            }
+            b"IPv4Address" => {
+                args.property.set(&ipv4.address.to_string());
+                Ok(())
+            }
+            b"IPv4AddressType" => {
+                let value = match ipv4.kind {
+                    IPv4AddressType::DHCP => "DHCP",
+                    IPv4AddressType::Static => "Static",
+                    IPv4AddressType::AutoIP => "Auto-IP",
+                    _ => "Unknown",
+                };
+                args.property.set(value);
+                Ok(())
+            }
+            b"DHCPServer" => {
+                args.property.set(&ipv4.dhcp_server.to_string());
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/rbus/nt_device_ipv6.rs
+++ b/ieee1905-core/src/rbus/nt_device_ipv6.rs
@@ -1,0 +1,101 @@
+use crate::cmdu_codec::IPv6AddressType;
+use crate::rbus::nt_device::RBus_Ieee1905Device_Node;
+use crate::rbus::peek_topology_database;
+use nom::AsBytes;
+use pnet::datalink::MacAddr;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+use std::net::Ipv6Addr;
+
+///
+/// Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.IPv6Address.{i}.
+/// - MACAddress
+/// - IPv6Address
+/// - IPv6AddressType
+/// - IPv6AddressOrigin
+///
+pub struct RBus_NetworkTopology_Ieee1905Device_IPv6;
+
+pub struct IPv6Info {
+    mac: MacAddr,
+    address: Ipv6Addr,
+    extra: Option<(IPv6AddressType, Ipv6Addr)>,
+}
+
+impl RBus_NetworkTopology_Ieee1905Device_IPv6 {
+    pub fn iter(node: &RBus_Ieee1905Device_Node) -> impl Iterator<Item = IPv6Info> {
+        node.ipv6_addresses()
+            .into_iter()
+            .flat_map(|e| e.entries.into_iter())
+            .flat_map(|e| {
+                let mac = e.mac_address;
+                let info = IPv6Info {
+                    mac,
+                    address: e.link_local_address,
+                    extra: None,
+                };
+                std::iter::once(info).chain(e.routable_addresses.into_iter().map(move |address| {
+                    IPv6Info {
+                        mac,
+                        address: address.ipv6_address,
+                        extra: Some((address.address_type, address.ipv6_originator)),
+                    }
+                }))
+            })
+    }
+}
+
+impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device_IPv6 {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+        Ok(Self::iter(&node).count() as u32)
+    }
+}
+
+impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_IPv6 {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let Some(address_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+        let Some(info) = Self::iter(&node).nth(address_index as usize) else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        match args.path_name.as_bytes() {
+            b"MACAddress" => {
+                args.property.set(&info.mac.to_string());
+                Ok(())
+            }
+            b"IPv6Address" => {
+                args.property.set(&info.address.to_string());
+                Ok(())
+            }
+            b"IPv6AddressType" => {
+                let value = match info.extra.map(|e| e.0) {
+                    Some(IPv6AddressType::DHCP) => "DHCP",
+                    Some(IPv6AddressType::Static) => "Static",
+                    Some(IPv6AddressType::SLAAC) => "SLAAC",
+                    None => "LinkLocal",
+                    _ => "Unknown",
+                };
+                args.property.set(value);
+                Ok(())
+            }
+            b"IPv6AddressOrigin" => {
+                let value = info.extra.map_or(Ipv6Addr::UNSPECIFIED, |e| e.1);
+                args.property.set(&value.to_string());
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -24,7 +24,7 @@ use crate::artifact_exchange_service::client::{
     ArtifactExchangeClient, ArtifactExchangeClientFactory,
 };
 use crate::cmdu_codec::{
-    ControlUrl, LinkMetricRx, LinkMetricRxPair, LinkMetricTx, LinkMetricTxPair,
+    ControlUrl, Ipv4, Ipv6, LinkMetricRx, LinkMetricRxPair, LinkMetricTx, LinkMetricTxPair,
 };
 use crate::interface_manager::get_interfaces;
 use crate::linux::if_link::RtnlLinkStats64;
@@ -361,6 +361,8 @@ pub struct Ieee1905DeviceData {
     pub supported_freq_band: Option<SupportedFreqBand>,
     pub ieee1905profile_version: Option<Ieee1905ProfileVersion>,
     pub device_identification_type: Option<DeviceIdentificationType>,
+    pub ipv4: Option<Ipv4>,
+    pub ipv6: Option<Ipv6>,
     pub link_metric_rx: Vec<LinkMetricRx>,
     pub link_metric_tx: Vec<LinkMetricTx>,
 }
@@ -1160,6 +1162,8 @@ impl TopologyDatabase {
         message_id: u16,
         device_information: DeviceIdentificationType,
         control_url: Option<ControlUrl>,
+        ipv4: Option<Ipv4>,
+        ipv6: Option<Ipv6>,
     ) -> bool {
         let mut nodes = self.nodes.write().await;
         let Some(node) = Self::find_node_by_port_mut(nodes.values_mut(), al_mac) else {
@@ -1176,6 +1180,9 @@ impl TopologyDatabase {
             warn!(%al_mac, "higher_layer_response — unexpected message id");
             return false;
         }
+
+        node.device_data.ipv4 = ipv4;
+        node.device_data.ipv6 = ipv6;
 
         if device_information.friendly_name == Self::HLE_ARTIFACT_EXCHANGE_SERVICE {
             let factory = self.artifact_exchange_client_factory.lock();


### PR DESCRIPTION
```
Parameter 14:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.IPv4AddressNumberOfEntries
              Type  : uint32
              Value : 0
Parameter 15:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.IPv6AddressNumberOfEntries
              Type  : uint32
              Value : 1
Parameter 16:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.IPv6Address.0.MACAddress
              Type  : string
              Value : 02:03:00:4f:ed:60
Parameter 17:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.IPv6Address.0.IPv6Address
              Type  : string
              Value : fe80::3:ff:fe4f:ed60
Parameter 18:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.IPv6Address.0.IPv6AddressType
              Type  : string
              Value : LinkLocal
Parameter 19:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.IPv6Address.0.IPv6AddressOrigin
              Type  : string
              Value : ::
```

Remark: we currently don't collect IPv4 and IPv6 information ourself. rbus will only provide information that we have or receive via HLE.