### PR TITLE
[#406] TR-181 v2-21 - Add `Device.IEEE1905.Network`

### DIFF
--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -1142,7 +1142,7 @@ impl TLVTrait for DeviceIdentificationType {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ControlUrl {
     pub url: String,
 }

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -921,6 +921,11 @@ impl CMDUHandler {
             return true;
         };
 
+        let Some(profile_version) = Ieee1905ProfileVersion::find(tlvs) else {
+            error!("HigherLayerResponse CMDU missing Ieee1905ProfileVersion TLV");
+            return true;
+        };
+
         let Some(device) = DeviceIdentificationType::find(tlvs) else {
             error!("HigherLayerResponse CMDU missing DeviceIdentificationType TLV");
             return true;
@@ -932,7 +937,15 @@ impl CMDUHandler {
         let ipv6 = Ipv6::find(tlvs);
 
         let result = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
-            .handle_higher_layer_response(al_mac, message_id, device, control_url, ipv4, ipv6)
+            .handle_higher_layer_response(
+                al_mac,
+                message_id,
+                profile_version,
+                device,
+                control_url,
+                ipv4,
+                ipv6,
+            )
             .await;
 
         info!(source = %source_mac, "HigherLayerResponse Processed");

--- a/ieee1905-core/src/rbus.rs
+++ b/ieee1905-core/src/rbus.rs
@@ -6,6 +6,11 @@ use crate::rbus::al_device::RBus_Al_Device;
 use crate::rbus::interface::RBus_Interface;
 use crate::rbus::interface_link::RBus_InterfaceLink;
 use crate::rbus::interface_link_metric::RBus_InterfaceLinkMetric;
+use crate::rbus::network::RBus_Network;
+use crate::rbus::network_al::RBus_Network_Al;
+use crate::rbus::network_al_bridge_tuple::RBus_Network_Al_BridgingTuple;
+use crate::rbus::network_al_ipv4::RBus_Network_Al_IPv4;
+use crate::rbus::network_al_ipv6::RBus_Network_Al_IPv6;
 use crate::rbus::nt::RBus_NetworkTopology;
 use crate::rbus::nt_device::RBus_NetworkTopology_Ieee1905Device;
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
@@ -29,6 +34,11 @@ mod al_device;
 mod interface;
 mod interface_link;
 mod interface_link_metric;
+mod network;
+mod network_al;
+mod network_al_bridge_tuple;
+mod network_al_ipv4;
+mod network_al_ipv6;
 mod nt;
 mod nt_device;
 mod nt_device_bridge;
@@ -80,6 +90,9 @@ impl RBusConnection {
                 rbus_object("IEEE1905", (
                     rbus_object("AL", (
                         rbus_object(format!("{instance}"), Self::register_nested()),
+                    )),
+                    rbus_object("Network", (
+                        rbus_object(format!("{instance}"), Self::build_network()),
                     )),
                 )),
             ))
@@ -175,6 +188,50 @@ impl RBusConnection {
                         )),
                     ),
                 )),
+            )),
+        )
+    }
+
+    #[rustfmt::skip]
+    fn build_network() -> impl RBusProviderElement {
+        (
+            rbus_property("Status", RBus_Network),
+            rbus_property("ALNumberOfEntries", RBus_Network),
+            rbus_table("AL", RBus_Network_Al, (
+                (
+                    rbus_property("IEEE1905Id", RBus_Network_Al),
+                    rbus_property("Version", RBus_Network_Al),
+                    rbus_property("RegistrarFreqBand", RBus_Network_Al),
+                    rbus_property("FriendlyName", RBus_Network_Al),
+                    rbus_property("ManufacturerName", RBus_Network_Al),
+                    rbus_property("ManufacturerModel", RBus_Network_Al),
+                    rbus_property("ControlURL", RBus_Network_Al),
+                ),
+                (
+                    rbus_property("IPv4AddressNumberOfEntries", RBus_Network_Al),
+                    rbus_table("IPv4Address", RBus_Network_Al_IPv4, (
+                        rbus_property("MACAddress", RBus_Network_Al_IPv4),
+                        rbus_property("IPv4Address", RBus_Network_Al_IPv4),
+                        rbus_property("IPv4AddressType", RBus_Network_Al_IPv4),
+                        rbus_property("DHCPServer", RBus_Network_Al_IPv4),
+                    ))
+                ),
+                (
+                    rbus_property("IPv6AddressNumberOfEntries", RBus_Network_Al),
+                    rbus_table("IPv6Address", RBus_Network_Al_IPv6, (
+                        rbus_property("MACAddress", RBus_Network_Al_IPv6),
+                        rbus_property("IPv6Address", RBus_Network_Al_IPv6),
+                        rbus_property("IPv6AddressType", RBus_Network_Al_IPv6),
+                        rbus_property("IPv6AddressOrigin", RBus_Network_Al_IPv6),
+                    ))
+                ),
+                (
+                    rbus_property("BridgingTupleNumberOfEntries", RBus_Network_Al),
+                    rbus_table("BridgingTuple", RBus_Network_Al_BridgingTuple, (
+                        rbus_property("InterfaceList", RBus_Network_Al_BridgingTuple),
+                    ))
+                ),
+                rbus_property("InterfaceNumberOfEntries", RBus_Network_Al),
             )),
         )
     }

--- a/ieee1905-core/src/rbus/network.rs
+++ b/ieee1905-core/src/rbus/network.rs
@@ -1,0 +1,42 @@
+use crate::rbus::peek_topology_database;
+use nom::AsBytes;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+
+///
+/// Device.IEEE1905.Network.
+/// - Status
+/// - ALNumberOfEntries
+///
+pub struct RBus_Network;
+
+impl RBusProviderTableSync for RBus_Network {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        let _ = args;
+        let db = peek_topology_database()?;
+        Ok(db.nodes.blocking_read().len() as u32)
+    }
+}
+
+impl RBusProviderGetter for RBus_Network {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        match args.path_name.as_bytes() {
+            b"Status" => {
+                args.property.set("Available");
+                Ok(())
+            }
+            b"ALNumberOfEntries" => {
+                let db = peek_topology_database()?;
+                let value = db.nodes.blocking_read().len() as u32;
+                args.property.set(&value);
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/rbus/network_al.rs
+++ b/ieee1905-core/src/rbus/network_al.rs
@@ -1,0 +1,137 @@
+use crate::cmdu_codec::{Ieee1905ProfileVersion, SupportedFreqBand};
+use crate::rbus::network_al_bridge_tuple::RBus_Network_Al_BridgingTuple;
+use crate::rbus::network_al_ipv4::RBus_Network_Al_IPv4;
+use crate::rbus::network_al_ipv6::RBus_Network_Al_IPv6;
+use crate::rbus::peek_topology_database;
+use crate::topology_manager::Ieee1905NodeInternal;
+use nom::AsBytes;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+use std::borrow::Cow;
+use tokio::sync::RwLockReadGuard;
+
+///
+/// Device.IEEE1905.Network.AL.{i}.
+/// - IEEE1905Id
+/// - Version
+/// - RegistrarFreqBand
+/// - FriendlyName
+/// - ManufacturerName
+/// - ManufacturerModel
+/// - ControlURL
+/// - IPv4AddressNumberOfEntries
+/// - IPv6AddressNumberOfEntries
+/// - InterfaceNumberOfEntries
+/// - BridgingTupleNumberOfEntries
+///
+pub struct RBus_Network_Al;
+
+impl RBus_Network_Al {
+    pub fn get_node(
+        table_idx: &[u32],
+    ) -> Result<(u32, RwLockReadGuard<'_, Ieee1905NodeInternal>), RBusError> {
+        let Some(node_index) = table_idx.get(0).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let db = peek_topology_database()?;
+        let nodes = db.nodes.blocking_read();
+
+        match RwLockReadGuard::try_map(nodes, |e| Some(e.get_index(node_index as usize)?.1)) {
+            Ok(e) => Ok((node_index, e)),
+            Err(_) => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}
+
+impl RBusProviderTableSync for RBus_Network_Al {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        let _ = args;
+        let db = peek_topology_database()?;
+        let len = db.nodes.blocking_read().len();
+        Ok(len as u32)
+    }
+}
+
+impl RBusProviderGetter for RBus_Network_Al {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let node = Self::get_node(args.table_idx)?.1;
+
+        match args.path_name.as_bytes() {
+            b"IEEE1905Id" => {
+                args.property.set(&node.device_data.al_mac.to_string());
+                Ok(())
+            }
+            b"Version" => {
+                let value = match node.device_data.ieee1905_profile_version {
+                    Ieee1905ProfileVersion::Ieee1905_1 => Cow::Borrowed("1905.1"),
+                    Ieee1905ProfileVersion::Ieee1905_1a => Cow::Borrowed("1905.1a"),
+                    Ieee1905ProfileVersion::Reserved(e) => format!("unknown({e})").into(),
+                };
+                args.property.set(&*value);
+                Ok(())
+            }
+            b"RegistrarFreqBand" => {
+                let value = node.device_data.supported_freq_band.map(|e| match e {
+                    SupportedFreqBand::Band_802_11_2_4 => Cow::Borrowed("802.11 2.4 GHz"),
+                    SupportedFreqBand::Band_802_11_5 => Cow::Borrowed("802.11 5 GHz"),
+                    SupportedFreqBand::Band_802_11_60 => Cow::Borrowed("802.11 60 GHz"),
+                    SupportedFreqBand::Reserved(e) => format!("unknown({e})").into(),
+                });
+                args.property.set(&*value.unwrap_or_default());
+                Ok(())
+            }
+            b"FriendlyName" => {
+                let info = node.device_data.device_identification_type.as_ref();
+                let value = info.map(|e| e.friendly_name.as_str());
+                args.property.set(value.unwrap_or_default());
+                Ok(())
+            }
+            b"ManufacturerName" => {
+                let info = node.device_data.device_identification_type.as_ref();
+                let value = info.map(|e| e.manufacturer_name.as_str());
+                args.property.set(value.unwrap_or_default());
+                Ok(())
+            }
+            b"ManufacturerModel" => {
+                let info = node.device_data.device_identification_type.as_ref();
+                let value = info.map(|e| e.manufacturer_model.as_str());
+                args.property.set(value.unwrap_or_default());
+                Ok(())
+            }
+            b"ControlURL" => {
+                let control_url = node.device_data.control_url.as_ref();
+                let value = control_url.map(|e| e.url.as_str());
+                args.property.set(value.unwrap_or_default());
+                Ok(())
+            }
+            b"IPv4AddressNumberOfEntries" => {
+                let value = RBus_Network_Al_IPv4::count(&node)?;
+                args.property.set(&value);
+                Ok(())
+            }
+            b"IPv6AddressNumberOfEntries" => {
+                let value = RBus_Network_Al_IPv6::count(&node)?;
+                args.property.set(&value);
+                Ok(())
+            }
+            b"InterfaceNumberOfEntries" => {
+                let interfaces = node.device_data.local_interface_list.as_deref();
+                let value = interfaces.unwrap_or_default().len();
+                args.property.set(&(value as u32));
+                Ok(())
+            }
+            b"BridgingTupleNumberOfEntries" => {
+                let tuples = RBus_Network_Al_BridgingTuple::collect(&node);
+                args.property.set(&(tuples.len() as u32));
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/rbus/network_al_bridge_tuple.rs
+++ b/ieee1905-core/src/rbus/network_al_bridge_tuple.rs
@@ -1,0 +1,68 @@
+use crate::rbus::network_al::RBus_Network_Al;
+use crate::topology_manager::Ieee1905NodeInternal;
+use indexmap::IndexMap;
+use nom::AsBytes;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+
+///
+/// Device.IEEE1905.Network.AL.{i}.BridgingTuple.{i}.
+/// - InterfaceList
+///
+pub struct RBus_Network_Al_BridgingTuple;
+
+impl RBus_Network_Al_BridgingTuple {
+    pub fn collect(node: &Ieee1905NodeInternal) -> IndexMap<u32, Vec<usize>> {
+        let interfaces = node.device_data.local_interface_list.as_deref();
+
+        let mut map = IndexMap::new();
+        for (index, interface) in interfaces.unwrap_or_default().iter().enumerate() {
+            let Some(tuple) = interface.bridging_tuple else {
+                continue;
+            };
+            map.entry(tuple).or_insert_with(Vec::new).push(index);
+        }
+        map
+    }
+}
+
+impl RBusProviderTableSync for RBus_Network_Al_BridgingTuple {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        let node = RBus_Network_Al::get_node(args.table_idx)?.1;
+        let tuples = Self::collect(&node);
+        Ok(tuples.len() as u32)
+    }
+}
+
+impl RBusProviderGetter for RBus_Network_Al_BridgingTuple {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let Some(tuple_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let (node_index, node) = RBus_Network_Al::get_node(args.table_idx)?;
+        let tuples = Self::collect(&node);
+
+        let Some(tuple) = tuples.get_index(tuple_index as usize) else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        match args.path_name.as_bytes() {
+            b"InterfaceList" => {
+                let iter = tuple.1.iter();
+                let interfaces =
+                    Vec::from_iter(iter.map(|e| {
+                        format!("Device.IEEE1905.Network.0.AL.{node_index}.Interface.{e}")
+                    }));
+                args.property.set(&interfaces.join(","));
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/rbus/network_al_ipv4.rs
+++ b/ieee1905-core/src/rbus/network_al_ipv4.rs
@@ -1,0 +1,86 @@
+use crate::cmdu_codec::IPv4AddressType;
+use crate::rbus::network_al::RBus_Network_Al;
+use crate::topology_manager::Ieee1905NodeInternal;
+use nom::AsBytes;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+use std::borrow::Cow;
+
+///
+/// Device.IEEE1905.Network.AL.{i}.IPv4Address.{i}.
+/// - MACAddress
+/// - IPv4Address
+/// - IPv4AddressType
+/// - DHCPServer
+///
+pub struct RBus_Network_Al_IPv4;
+
+impl RBus_Network_Al_IPv4 {
+    pub fn count(node: &Ieee1905NodeInternal) -> Result<u32, RBusError> {
+        let Some(ipv4) = node.device_data.ipv4.as_ref() else {
+            return Ok(0);
+        };
+        Ok(ipv4.entries.iter().map(|e| e.addresses.len() as u32).sum())
+    }
+}
+
+impl RBusProviderTableSync for RBus_Network_Al_IPv4 {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        Self::count(&RBus_Network_Al::get_node(args.table_idx)?.1)
+    }
+}
+
+impl RBusProviderGetter for RBus_Network_Al_IPv4 {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let Some(address_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let node = RBus_Network_Al::get_node(args.table_idx)?.1;
+
+        let Some(ipv4) = node.device_data.ipv4.as_ref() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let Some((mac, address)) = ipv4
+            .entries
+            .iter()
+            .flat_map(|e| e.addresses.iter().map(|address| (e.mac, address)))
+            .nth(address_index as usize)
+        else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        match args.path_name.as_bytes() {
+            b"MACAddress" => {
+                args.property.set(&mac.to_string());
+                Ok(())
+            }
+            b"IPv4Address" => {
+                args.property.set(&address.address.to_string());
+                Ok(())
+            }
+            b"IPv4AddressType" => {
+                let value = match address.kind {
+                    IPv4AddressType::Unknown => Cow::Borrowed("Unknown"),
+                    IPv4AddressType::DHCP => Cow::Borrowed("DHCP"),
+                    IPv4AddressType::Static => Cow::Borrowed("Static"),
+                    IPv4AddressType::AutoIP => Cow::Borrowed("Auto-IP"),
+                    IPv4AddressType::Reserved(e) => format!("Unknown({e})").into(),
+                };
+                args.property.set(&*value);
+                Ok(())
+            }
+            b"DHCPServer" => {
+                args.property.set(&address.dhcp_server.to_string());
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/rbus/network_al_ipv6.rs
+++ b/ieee1905-core/src/rbus/network_al_ipv6.rs
@@ -1,0 +1,102 @@
+use crate::cmdu_codec::IPv6AddressType;
+use crate::rbus::network_al::RBus_Network_Al;
+use crate::topology_manager::Ieee1905NodeInternal;
+use nom::AsBytes;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+use std::borrow::Cow;
+use std::net::Ipv6Addr;
+
+///
+/// Device.IEEE1905.Network.AL.{i}.IPv6Address.{i}.
+/// - MACAddress
+/// - IPv6Address
+/// - IPv6AddressType
+/// - IPv6AddressOrigin
+///
+pub struct RBus_Network_Al_IPv6;
+
+impl RBus_Network_Al_IPv6 {
+    pub fn count(node: &Ieee1905NodeInternal) -> Result<u32, RBusError> {
+        let Some(ipv6) = node.device_data.ipv6.as_ref() else {
+            return Ok(0);
+        };
+        Ok(ipv6
+            .entries
+            .iter()
+            .map(|e| e.routable_addresses.len() as u32 + 1)
+            .sum())
+    }
+}
+
+impl RBusProviderTableSync for RBus_Network_Al_IPv6 {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        Self::count(&RBus_Network_Al::get_node(args.table_idx)?.1)
+    }
+}
+
+impl RBusProviderGetter for RBus_Network_Al_IPv6 {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let Some(address_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let node = RBus_Network_Al::get_node(args.table_idx)?.1;
+
+        let Some(ipv6) = node.device_data.ipv6.as_ref() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let Some((mac, address, extra)) = ipv6
+            .entries
+            .iter()
+            .flat_map(|e| {
+                let link_local = std::iter::once((e.mac_address, e.link_local_address, None));
+                let other_addresses = e.routable_addresses.iter().map(|address| {
+                    (
+                        e.mac_address,
+                        address.ipv6_address,
+                        Some((address.address_type, address.ipv6_originator)),
+                    )
+                });
+                std::iter::chain(link_local, other_addresses)
+            })
+            .nth(address_index as usize)
+        else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        match args.path_name.as_bytes() {
+            b"MACAddress" => {
+                args.property.set(&mac.to_string());
+                Ok(())
+            }
+            b"IPv6Address" => {
+                args.property.set(&address.to_string());
+                Ok(())
+            }
+            b"IPv6AddressType" => {
+                let value = extra.map(|e| match e.0 {
+                    IPv6AddressType::Unknown => Cow::Borrowed("Unknown"),
+                    IPv6AddressType::DHCP => Cow::Borrowed("DHCP"),
+                    IPv6AddressType::Static => Cow::Borrowed("Static"),
+                    IPv6AddressType::SLAAC => Cow::Borrowed("SLAAC"),
+                    IPv6AddressType::Reserved(e) => format!("Unknown({e})").into(),
+                });
+                args.property.set(value.as_deref().unwrap_or("LinkLocal"));
+                Ok(())
+            }
+            b"IPv6AddressOrigin" => {
+                let value = extra.map_or(Ipv6Addr::UNSPECIFIED, |e| e.1);
+                args.property.set(&value.to_string());
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/rbus/nt_device.rs
+++ b/ieee1905-core/src/rbus/nt_device.rs
@@ -175,7 +175,7 @@ impl<'a> RBus_Ieee1905Device_Node<'a> {
     pub fn ieee1905profile_version(&self) -> Option<Ieee1905ProfileVersion> {
         match self {
             RBus_Ieee1905Device_Node::Local(_) => Some(Ieee1905ProfileVersion::Ieee1905_1),
-            RBus_Ieee1905Device_Node::Remote(e) => e.device_data.ieee1905profile_version,
+            RBus_Ieee1905Device_Node::Remote(e) => Some(e.device_data.ieee1905_profile_version),
         }
     }
 

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -359,7 +359,8 @@ pub struct Ieee1905DeviceData {
     pub registry_role: Option<Role>,
     pub supported_fragmentation: CMDUFragmentation,
     pub supported_freq_band: Option<SupportedFreqBand>,
-    pub ieee1905profile_version: Option<Ieee1905ProfileVersion>,
+    pub ieee1905_profile_version: Ieee1905ProfileVersion,
+    pub control_url: Option<ControlUrl>,
     pub device_identification_type: Option<DeviceIdentificationType>,
     pub ipv4: Option<Ipv4>,
     pub ipv6: Option<Ipv6>,
@@ -398,14 +399,6 @@ impl Ieee1905DeviceData {
         if let Some(interfaces) = other.local_interface_list {
             changed = true;
             self.local_interface_list = Some(interfaces);
-        }
-        if let Some(value) = other.ieee1905profile_version {
-            changed = true;
-            self.ieee1905profile_version = Some(value);
-        }
-        if let Some(value) = other.device_identification_type {
-            changed = true;
-            self.device_identification_type = Some(value);
         }
         changed
     }
@@ -1160,6 +1153,7 @@ impl TopologyDatabase {
         &self,
         al_mac: MacAddr,
         message_id: u16,
+        profile_version: Ieee1905ProfileVersion,
         device_information: DeviceIdentificationType,
         control_url: Option<ControlUrl>,
         ipv4: Option<Ipv4>,
@@ -1183,10 +1177,20 @@ impl TopologyDatabase {
 
         node.device_data.ipv4 = ipv4;
         node.device_data.ipv6 = ipv6;
+        node.device_data.ieee1905_profile_version = profile_version;
+        node.device_data.control_url = control_url;
+
+        let device_information = node
+            .device_data
+            .device_identification_type
+            .insert(device_information);
 
         if device_information.friendly_name == Self::HLE_ARTIFACT_EXCHANGE_SERVICE {
             let factory = self.artifact_exchange_client_factory.lock();
-            node.update_artifact_exchange_client(factory.as_ref(), control_url.map(|e| e.url));
+            node.update_artifact_exchange_client(
+                factory.as_ref(),
+                node.device_data.control_url.as_ref().map(|e| e.url.clone()),
+            );
             return true;
         }
         false


### PR DESCRIPTION
```
Parameter  1:
              Name  : Device.IEEE1905.Network.0.Status
              Type  : string
              Value : Available
Parameter  2:
              Name  : Device.IEEE1905.Network.0.ALNumberOfEntries
              Type  : uint32
              Value : 1
Parameter  3:
              Name  : Device.IEEE1905.Network.0.AL.0.IEEE1905Id
              Type  : string
              Value : 02:03:00:4f:ed:60
Parameter  4:
              Name  : Device.IEEE1905.Network.0.AL.0.Version
              Type  : string
              Value : 1905.1a
Parameter  5:
              Name  : Device.IEEE1905.Network.0.AL.0.RegistrarFreqBand
              Type  : string
              Value : 
Parameter  6:
              Name  : Device.IEEE1905.Network.0.AL.0.FriendlyName
              Type  : string
              Value : ArtifactExchangeService
Parameter  7:
              Name  : Device.IEEE1905.Network.0.AL.0.ManufacturerName
              Type  : string
              Value : 
Parameter  8:
              Name  : Device.IEEE1905.Network.0.AL.0.ManufacturerModel
              Type  : string
              Value : 
Parameter  9:
              Name  : Device.IEEE1905.Network.0.AL.0.ControlURL
              Type  : string
              Value : http://[fe80::3:ff:fe4f:ed60]:6666/
Parameter 10:
              Name  : Device.IEEE1905.Network.0.AL.0.IPv4AddressNumberOfEntries
              Type  : uint32
              Value : 0
Parameter 11:
              Name  : Device.IEEE1905.Network.0.AL.0.IPv6AddressNumberOfEntries
              Type  : uint32
              Value : 1
Parameter 12:
              Name  : Device.IEEE1905.Network.0.AL.0.IPv6Address.0.MACAddress
              Type  : string
              Value : 02:03:00:4f:ed:60
Parameter 13:
              Name  : Device.IEEE1905.Network.0.AL.0.IPv6Address.0.IPv6Address
              Type  : string
              Value : fe80::3:ff:fe4f:ed60
Parameter 14:
              Name  : Device.IEEE1905.Network.0.AL.0.IPv6Address.0.IPv6AddressType
              Type  : string
              Value : LinkLocal
Parameter 15:
              Name  : Device.IEEE1905.Network.0.AL.0.IPv6Address.0.IPv6AddressOrigin
              Type  : string
              Value : ::
Parameter 16:
              Name  : Device.IEEE1905.Network.0.AL.0.BridgingTupleNumberOfEntries
              Type  : uint32
              Value : 1
Parameter 17:
              Name  : Device.IEEE1905.Network.0.AL.0.BridgingTuple.0.InterfaceList
              Type  : string
              Value : Device.IEEE1905.Network.0.AL.0.Interface.0,Device.IEEE1905.Network.0.AL.0.Interface.1,Device.IEEE1905.Network.0.AL.0.Interface.2
Parameter 18:
              Name  : Device.IEEE1905.Network.0.AL.0.InterfaceNumberOfEntries
              Type  : uint32
              Value : 3
```

Remark: we currently don't collect IPv4 and IPv6 information ourself. rbus will only provide information that we have or receive via HLE.