### PR TITLE
[#406] TR-181 v2-21 - Add `Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.IEEE1905Neighbor.{i}.`

### DIFF
--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -25,18 +25,18 @@ use nom::{
     IResult, Parser,
     bytes::complete::take,
     error::{Error, ErrorKind},
-    number::complete::{be_i8, be_u8, be_u16, be_u32},
+    number::complete::{be_i8, be_u16, be_u32, be_u8},
 };
 
+// Internal modules
+use crate::cmdu_reassembler::CmduReassemblyError;
+use crate::tlv_cmdu_codec::{TLV, TLVTrait};
 use anyhow::bail;
 use nom::combinator::{all_consuming, cond};
 use nom::multi::{count, length_count, many0};
 use pnet::datalink::MacAddr;
 use std::fmt::{Debug, Display, Formatter};
 use std::net::{Ipv4Addr, Ipv6Addr};
-// Internal modules
-use crate::cmdu_reassembler::CmduReassemblyError;
-use crate::tlv_cmdu_codec::{TLV, TLVTrait};
 
 ///////////////////////////////////////////////////////////////////////////
 //DEFINITION OF CMDU TYPES and IEEE1905 TLVs
@@ -1566,7 +1566,7 @@ impl TLVTrait for LinkMetricQuery {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkMetricTx {
     pub source_al_mac: MacAddr,
     pub neighbour_al_mac: MacAddr,
@@ -1604,7 +1604,7 @@ impl TLVTrait for LinkMetricTx {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkMetricTxPair {
     pub receiver_interface_mac: MacAddr,
     pub neighbour_interface_mac: MacAddr,
@@ -1661,7 +1661,7 @@ impl LinkMetricTxPair {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkMetricRx {
     pub source_al_mac: MacAddr,
     pub neighbour_al_mac: MacAddr,
@@ -1699,13 +1699,13 @@ impl TLVTrait for LinkMetricRx {
 }
 
 ///////////////////////////////////////////////////////////////////////////
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LinkMetricRxPair {
     pub receiver_interface_mac: MacAddr,
     pub neighbour_interface_mac: MacAddr,
     pub interface_type: MediaType,
     pub packet_errors: u32,
-    pub transmitted_packets: u32,
+    pub packets_received: u32,
     pub rssi: i8,
 }
 
@@ -1715,7 +1715,7 @@ impl LinkMetricRxPair {
         let (input, neighbour_interface_mac) = take_mac_addr(input)?;
         let (input, interface_type) = MediaType::parse(input)?;
         let (input, packet_errors) = be_u32(input)?;
-        let (input, transmitted_packets) = be_u32(input)?;
+        let (input, packets_received) = be_u32(input)?;
         let (input, rssi) = be_i8(input)?;
 
         Ok((
@@ -1725,7 +1725,7 @@ impl LinkMetricRxPair {
                 neighbour_interface_mac,
                 interface_type,
                 packet_errors,
-                transmitted_packets,
+                packets_received,
                 rssi,
             },
         ))
@@ -1737,7 +1737,7 @@ impl LinkMetricRxPair {
         vec.extend(self.neighbour_interface_mac.octets());
         vec.extend(self.interface_type.serialize());
         vec.extend(self.packet_errors.to_be_bytes());
-        vec.extend(self.transmitted_packets.to_be_bytes());
+        vec.extend(self.packets_received.to_be_bytes());
         vec.extend(self.rssi.to_be_bytes());
         vec
     }
@@ -4071,7 +4071,7 @@ pub mod tests {
         );
         assert_eq!(pair.interface_type, MediaType::ETHERNET_802_3ab);
         assert_eq!(pair.packet_errors, 0x13);
-        assert_eq!(pair.transmitted_packets, 0x42);
+        assert_eq!(pair.packets_received, 0x42);
         assert_eq!(pair.rssi, 0x10);
 
         let serialized = parsed.serialize();

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -630,12 +630,11 @@ pub async fn cmdu_link_metric_response_transmission(
         let local_interfaces = topology_db.local_interface_list.read().await;
         let local_interfaces = local_interfaces.as_deref().unwrap_or_default();
 
-        let Some(interface) = local_interfaces.iter().find(|e| {
-            e.ieee1905_neighbors
-                .iter()
-                .flatten()
-                .any(|e| neighbor.device_data.has_port(e.neighbor_al_mac))
-        }) else {
+        let Some((rx, tx)) = local_interfaces
+            .iter()
+            .filter_map(|e| e.get_link_metric_pair(&neighbor.device_data))
+            .next()
+        else {
             warn!(
                 al_mac = %neighbor.device_data.al_mac,
                 source = %neighbor.device_data.destination_frame_mac,
@@ -644,54 +643,19 @@ pub async fn cmdu_link_metric_response_transmission(
             continue;
         };
 
-        let link_stats = interface.link_stats.unwrap_or_default();
-        let neighbour_if1 = neighbor.device_data.destination_mac;
-        let neighbour_if2 = neighbor.device_data.destination_frame_mac;
-        let neighbour_if = neighbour_if1.unwrap_or(neighbour_if2);
-
-        fn to_u16_sat(value: u64) -> u16 {
-            u16::try_from(value).unwrap_or(u16::MAX)
-        }
-
-        fn to_u32_sat(value: u64) -> u32 {
-            u32::try_from(value).unwrap_or(u32::MAX)
-        }
-
         if include_rx {
-            let pair = LinkMetricRxPair {
-                receiver_interface_mac: interface.mac,
-                neighbour_interface_mac: neighbour_if,
-                interface_type: interface.media_type,
-                packet_errors: to_u32_sat(link_stats.rx_errors),
-                transmitted_packets: to_u32_sat(link_stats.rx_packets),
-                rssi: interface.signal_strength_dbm.unwrap_or(0xffu8 as i8),
-            };
-
             tlvs.push(TLV::from(LinkMetricRx {
                 source_al_mac: local_al_mac_address,
                 neighbour_al_mac: neighbor.device_data.al_mac,
-                interface_pairs: vec![pair],
+                interface_pairs: vec![rx],
             }));
         }
 
         if include_tx {
-            let phy_rate = to_u16_sat(interface.phy_rate.unwrap_or_default() / 1_000_000);
-            let pair = LinkMetricTxPair {
-                receiver_interface_mac: interface.mac,
-                neighbour_interface_mac: neighbour_if,
-                interface_type: interface.media_type,
-                has_more_ieee802_bridges: interface.bridging_flag.into(),
-                packet_errors: to_u32_sat(link_stats.tx_errors),
-                transmitted_packets: to_u32_sat(link_stats.tx_packets),
-                mac_throughput_capacity: phy_rate,
-                link_availability: interface.link_availability.unwrap_or(100).into(),
-                phy_rate,
-            };
-
             tlvs.push(TLV::from(LinkMetricTx {
                 source_al_mac: local_al_mac_address,
                 neighbour_al_mac: neighbor.device_data.al_mac,
-                interface_pairs: vec![pair],
+                interface_pairs: vec![tx],
             }));
         }
     }

--- a/ieee1905-core/src/rbus.rs
+++ b/ieee1905-core/src/rbus.rs
@@ -10,6 +10,8 @@ use crate::rbus::nt::RBus_NetworkTopology;
 use crate::rbus::nt_device::RBus_NetworkTopology_Ieee1905Device;
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
 use crate::rbus::nt_device_bridge_list::RBus_NetworkTopology_Ieee1905Device_BridgingTuple_InterfaceList;
+use crate::rbus::nt_device_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor;
+use crate::rbus::nt_device_ieee1905_neighbor_metric::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use anyhow::bail;
 use rbus_core::{RBusError, RBusLibrary, RBusLogHandler, RBusLogLevel, RBusLogRecord};
@@ -29,6 +31,8 @@ mod nt;
 mod nt_device;
 mod nt_device_bridge;
 mod nt_device_bridge_list;
+mod nt_device_ieee1905_neighbor;
+mod nt_device_ieee1905_neighbor_metric;
 mod nt_device_non_ieee1905_neighbor;
 
 ///
@@ -121,7 +125,25 @@ impl RBusConnection {
                     rbus_table("NonIEEE1905Neighbor", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor, (
                         rbus_property("LocalInterface", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor),
                         rbus_property("NeighborInterfaceId", RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor),
-                    ))
+                    )),
+                    rbus_property("IEEE1905NeighborNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
+                    rbus_table("IEEE1905Neighbor", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor, (
+                        rbus_property("LocalInterface", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
+                        rbus_property("NeighborDeviceId", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
+                        rbus_property("MetricNumberOfEntries", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor),
+                        rbus_table("Metric", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric, (
+                            rbus_property("NeighborMACAddress", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("IEEE802dot1Bridge", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("PacketErrors", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("PacketErrorsReceived", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("TransmittedPackets", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("PacketsReceived", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("MACThroughputCapacity", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("LinkAvailability", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("PHYRate", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                            rbus_property("RSSI", RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric),
+                        )),
+                    )),
                 )),
             )),
         )

--- a/ieee1905-core/src/rbus/nt_device.rs
+++ b/ieee1905-core/src/rbus/nt_device.rs
@@ -1,6 +1,7 @@
 use crate::TopologyDatabase;
 use crate::cmdu_codec::{DeviceIdentificationType, Ieee1905ProfileVersion, SupportedFreqBand};
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
+use crate::rbus::nt_device_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use crate::rbus::peek_topology_database;
 use crate::topology_manager::{
@@ -23,6 +24,7 @@ use tokio::sync::RwLockReadGuard;
 /// - ManufacturerName
 /// - ManufacturerModel
 /// - BridgingTupleNumberOfEntries
+/// - IEEE1905NeighborNumberOfEntries
 /// - NonIEEE1905NeighborNumberOfEntries
 ///
 pub struct RBus_NetworkTopology_Ieee1905Device;
@@ -114,10 +116,14 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
                 args.property.set(&(tuples.len() as u32));
                 Ok(())
             }
+            b"IEEE1905NeighborNumberOfEntries" => {
+                let iter = RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor::iter(&node);
+                args.property.set(&(iter.count() as u32));
+                Ok(())
+            }
             b"NonIEEE1905NeighborNumberOfEntries" => {
-                let neighbors =
-                    RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor::iter_neighbors(&node);
-                args.property.set(&(neighbors.count() as u32));
+                let iter = RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor::iter(&node);
+                args.property.set(&(iter.count() as u32));
                 Ok(())
             }
             _ => Err(RBusError::ElementDoesNotExists),

--- a/ieee1905-core/src/rbus/nt_device_ieee1905_neighbor.rs
+++ b/ieee1905-core/src/rbus/nt_device_ieee1905_neighbor.rs
@@ -1,44 +1,51 @@
+use crate::cmdu::IEEE1905Neighbor;
 use crate::rbus::nt_device::RBus_Ieee1905Device_Node;
+use crate::rbus::nt_device_ieee1905_neighbor_metric::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric;
 use crate::rbus::peek_topology_database;
 use nom::AsBytes;
-use pnet::datalink::MacAddr;
 use rbus_core::RBusError;
 use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
 use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
 
 ///
-/// Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.NonIEEE1905Neighbor.{i}.
+/// Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.IEEE1905Neighbor.{i}.
 /// - LocalInterface
-/// - NeighborInterfaceId
+/// - NeighborDeviceId
+/// - MetricNumberOfEntries
 ///
-pub struct RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
+pub struct RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor;
 
-impl RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor {
+pub struct Ieee1905Neighbor<'a> {
+    if_index: usize,
+    pub neighbor: &'a IEEE1905Neighbor,
+}
+
+impl RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor {
     pub fn iter<'a>(
         node: &'a RBus_Ieee1905Device_Node,
-    ) -> impl Iterator<Item = (usize, MacAddr)> + 'a {
+    ) -> impl Iterator<Item = Ieee1905Neighbor<'a>> + 'a {
         let interfaces = node.local_interfaces();
-        interfaces.enumerate().flat_map(|(index, e)| {
-            let neighbours = &e.non_ieee1905_neighbors;
-            let neighbours = neighbours.as_deref().unwrap_or_default();
-            neighbours.iter().map(move |e| (index, *e))
+        interfaces.enumerate().flat_map(|(if_index, e)| {
+            let neighbours = e.ieee1905_neighbors.as_deref().unwrap_or_default();
+            neighbours
+                .iter()
+                .map(move |neighbor| Ieee1905Neighbor { if_index, neighbor })
         })
     }
 }
 
-impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor {
+impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor {
     type UserData = ();
 
     fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
         let db = peek_topology_database()?;
         let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
         let count = Self::iter(&node).count();
-
         Ok(count as u32)
     }
 }
 
-impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor {
+impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor {
     type UserData = ();
 
     fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
@@ -50,17 +57,26 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neigh
         let (node_index, node) = RBus_Ieee1905Device_Node::from(db, args.table_idx)?;
         let mut neighbours = Self::iter(&node);
 
-        let Some((if_index, neighbour)) = neighbours.nth(neighbour_index as usize) else {
+        let Some(info) = neighbours.nth(neighbour_index as usize) else {
             return Err(RBusError::ElementDoesNotExists);
         };
 
         match args.path_name.as_bytes() {
             b"LocalInterface" => {
+                let if_index = info.if_index;
                 args.property.set(&format!("Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.{node_index}.Interface.{if_index}"));
                 Ok(())
             }
-            b"NeighborInterfaceId" => {
-                args.property.set(&neighbour.to_string());
+            b"NeighborDeviceId" => {
+                let mac = info.neighbor.neighbor_al_mac.to_string();
+                args.property.set(&mac);
+                Ok(())
+            }
+            b"MetricNumberOfEntries" => {
+                let metrics = RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric::collect(
+                    &node, &info,
+                )?;
+                args.property.set(&(metrics.len() as u32));
                 Ok(())
             }
             _ => Err(RBusError::ElementDoesNotExists),

--- a/ieee1905-core/src/rbus/nt_device_ieee1905_neighbor_metric.rs
+++ b/ieee1905-core/src/rbus/nt_device_ieee1905_neighbor_metric.rs
@@ -1,0 +1,197 @@
+use crate::cmdu_codec::{LinkMetricRxPair, LinkMetricTxPair};
+use crate::rbus::nt_device::RBus_Ieee1905Device_Node;
+use crate::rbus::nt_device_ieee1905_neighbor::{
+    Ieee1905Neighbor, RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor,
+};
+use crate::rbus::peek_topology_database;
+use either::Either;
+use nom::AsBytes;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+use std::borrow::Cow;
+
+///
+/// Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.IEEE1905Neighbor.{i}.Metric.{i}.
+/// - NeighborMACAddress
+/// - IEEE802dot1Bridge
+/// - PacketErrors
+/// - PacketErrorsReceived
+/// - TransmittedPackets
+/// - PacketsReceived
+/// - MACThroughputCapacity
+/// - LinkAvailability
+/// - PHYRate
+/// - RSSI
+///
+pub struct RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric;
+
+impl RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric {
+    pub fn collect<'a>(
+        node: &'a RBus_Ieee1905Device_Node,
+        neighbor: &'a Ieee1905Neighbor,
+    ) -> Result<Vec<Either<Cow<'a, LinkMetricRxPair>, Cow<'a, LinkMetricTxPair>>>, RBusError> {
+        let mut vec = Vec::new();
+        let neighbor_al_mac = neighbor.neighbor.neighbor_al_mac;
+
+        match node {
+            RBus_Ieee1905Device_Node::Local(e) => {
+                let db = peek_topology_database()?;
+                let nodes = db.nodes.blocking_read();
+                let node = nodes
+                    .iter()
+                    .find(|e| e.1.device_data.has_port(neighbor_al_mac))
+                    .ok_or_else(|| RBusError::ElementDoesNotExists)?;
+
+                for interface in e.iter() {
+                    let Some((rx, tx)) = interface.get_link_metric_pair(&node.1.device_data) else {
+                        continue;
+                    };
+                    vec.push(Either::Left(Cow::Owned(rx)));
+                    vec.push(Either::Right(Cow::Owned(tx)));
+                }
+            }
+            RBus_Ieee1905Device_Node::Remote(e) => {
+                for metric in e.device_data.link_metric_rx.iter() {
+                    if metric.neighbour_al_mac != neighbor_al_mac {
+                        continue;
+                    }
+                    for pair in metric.interface_pairs.iter() {
+                        vec.push(Either::Left(Cow::Borrowed(pair)));
+                    }
+                }
+                for metric in e.device_data.link_metric_tx.iter() {
+                    if metric.neighbour_al_mac != neighbor_al_mac {
+                        continue;
+                    }
+                    for pair in metric.interface_pairs.iter() {
+                        vec.push(Either::Right(Cow::Borrowed(pair)));
+                    }
+                }
+            }
+        };
+        Ok(vec)
+    }
+}
+
+impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        let Some(neighbour_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+        let mut neighbors = RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor::iter(&node);
+
+        let Some(neighbor) = neighbors.nth(neighbour_index as usize) else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let metrics = Self::collect(&node, &neighbor)?;
+        Ok(metrics.len() as u32)
+    }
+}
+
+impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let Some(neighbour_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+        let Some(metric_index) = args.table_idx.get(2).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+
+        let mut neighbors = RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor::iter(&node);
+        let Some(neighbor) = neighbors.nth(neighbour_index as usize) else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let metrics = Self::collect(&node, &neighbor)?;
+        let Some(metric) = metrics.get(metric_index as usize) else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        match args.path_name.as_bytes() {
+            b"NeighborMACAddress" => {
+                let mac = match metric {
+                    Either::Left(e) => e.neighbour_interface_mac,
+                    Either::Right(e) => e.neighbour_interface_mac,
+                };
+                args.property.set(&mac.to_string());
+                Ok(())
+            }
+            b"IEEE802dot1Bridge" => match metric {
+                Either::Left(_) => Err(RBusError::ElementDoesNotExists),
+                Either::Right(e) => {
+                    args.property.set(&(e.has_more_ieee802_bridges != 0));
+                    Ok(())
+                }
+            },
+            b"PacketErrors" => match metric {
+                Either::Left(_) => Err(RBusError::ElementDoesNotExists),
+                Either::Right(e) => {
+                    args.property.set(&e.packet_errors);
+                    Ok(())
+                }
+            },
+            b"PacketErrorsReceived" => match metric {
+                Either::Left(e) => {
+                    args.property.set(&e.packet_errors);
+                    Ok(())
+                }
+                Either::Right(_) => Err(RBusError::ElementDoesNotExists),
+            },
+            b"TransmittedPackets" => match metric {
+                Either::Left(_) => Err(RBusError::ElementDoesNotExists),
+                Either::Right(e) => {
+                    args.property.set(&e.transmitted_packets);
+                    Ok(())
+                }
+            },
+            b"PacketsReceived" => match metric {
+                Either::Left(e) => {
+                    args.property.set(&e.packets_received);
+                    Ok(())
+                }
+                Either::Right(_) => Err(RBusError::ElementDoesNotExists),
+            },
+            b"MACThroughputCapacity" => match metric {
+                Either::Left(_) => Err(RBusError::ElementDoesNotExists),
+                Either::Right(e) => {
+                    args.property.set(&e.mac_throughput_capacity);
+                    Ok(())
+                }
+            },
+            b"LinkAvailability" => match metric {
+                Either::Left(_) => Err(RBusError::ElementDoesNotExists),
+                Either::Right(e) => {
+                    args.property.set(&e.link_availability);
+                    Ok(())
+                }
+            },
+            b"PHYRate" => match metric {
+                Either::Left(_) => Err(RBusError::ElementDoesNotExists),
+                Either::Right(e) => {
+                    args.property.set(&e.phy_rate);
+                    Ok(())
+                }
+            },
+            b"RSSI" => match metric {
+                Either::Left(e) => {
+                    args.property.set(&e.rssi);
+                    Ok(())
+                }
+                Either::Right(_) => Err(RBusError::ElementDoesNotExists),
+            },
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -23,7 +23,9 @@
 use crate::artifact_exchange_service::client::{
     ArtifactExchangeClient, ArtifactExchangeClientFactory,
 };
-use crate::cmdu_codec::{ControlUrl, LinkMetricRx, LinkMetricTx};
+use crate::cmdu_codec::{
+    ControlUrl, LinkMetricRx, LinkMetricRxPair, LinkMetricTx, LinkMetricTxPair,
+};
 use crate::interface_manager::get_interfaces;
 use crate::linux::if_link::RtnlLinkStats64;
 use crate::lldpdu::PortId;
@@ -109,6 +111,55 @@ pub struct Ieee1905LocalInterface {
     pub flags: Iff,
     pub link_stats: Option<RtnlLinkStats64>,
     pub data: Ieee1905InterfaceData,
+}
+
+impl Ieee1905LocalInterface {
+    pub fn get_link_metric_pair(
+        &self,
+        neighbor: &Ieee1905DeviceData,
+    ) -> Option<(LinkMetricRxPair, LinkMetricTxPair)> {
+        let neighbors = self.ieee1905_neighbors.as_ref()?;
+        neighbors
+            .iter()
+            .find(|e| neighbor.has_port(e.neighbor_al_mac))?;
+
+        let neighbour_if1 = neighbor.destination_mac;
+        let neighbour_if2 = neighbor.destination_frame_mac;
+        let neighbour_if = neighbour_if1.unwrap_or(neighbour_if2);
+
+        fn to_u16_sat(value: u64) -> u16 {
+            u16::try_from(value).unwrap_or(u16::MAX)
+        }
+
+        fn to_u32_sat(value: u64) -> u32 {
+            u32::try_from(value).unwrap_or(u32::MAX)
+        }
+
+        let link_stats = self.link_stats.unwrap_or_default();
+        let rx = LinkMetricRxPair {
+            receiver_interface_mac: self.mac,
+            neighbour_interface_mac: neighbour_if,
+            interface_type: self.media_type,
+            packet_errors: to_u32_sat(link_stats.rx_errors),
+            packets_received: to_u32_sat(link_stats.rx_packets),
+            rssi: self.signal_strength_dbm.unwrap_or(0xffu8 as i8),
+        };
+
+        let phy_rate = to_u16_sat(self.phy_rate.unwrap_or_default() / 1_000_000);
+        let tx = LinkMetricTxPair {
+            receiver_interface_mac: self.mac,
+            neighbour_interface_mac: neighbour_if,
+            interface_type: self.media_type,
+            has_more_ieee802_bridges: self.bridging_flag.into(),
+            packet_errors: to_u32_sat(link_stats.tx_errors),
+            transmitted_packets: to_u32_sat(link_stats.tx_packets),
+            mac_throughput_capacity: phy_rate,
+            link_availability: self.link_availability.unwrap_or(100).into(),
+            phy_rate,
+        };
+
+        Some((rx, tx))
+    }
 }
 
 impl Default for Ieee1905LocalInterface {
@@ -310,6 +361,8 @@ pub struct Ieee1905DeviceData {
     pub supported_freq_band: Option<SupportedFreqBand>,
     pub ieee1905profile_version: Option<Ieee1905ProfileVersion>,
     pub device_identification_type: Option<DeviceIdentificationType>,
+    pub link_metric_rx: Vec<LinkMetricRx>,
+    pub link_metric_tx: Vec<LinkMetricTx>,
 }
 
 impl Ieee1905DeviceData {
@@ -329,10 +382,7 @@ impl Ieee1905DeviceData {
             local_interface_mac,
             local_interface_list,
             registry_role,
-            supported_fragmentation: Default::default(),
-            supported_freq_band: None,
-            ieee1905profile_version: None,
-            device_identification_type: None,
+            ..Default::default()
         }
     }
 
@@ -1060,10 +1110,11 @@ impl TopologyDatabase {
             return;
         }
 
-        if tracing::enabled!(tracing::Level::TRACE) {
-            trace!(%source, "link metric rx stats: {:#?}", Vec::from_iter(link_metric_rx));
-            trace!(%source, "link metric tx stats: {:#?}", Vec::from_iter(link_metric_tx));
-        }
+        node.device_data.link_metric_rx = link_metric_rx.into_iter().collect();
+        node.device_data.link_metric_tx = link_metric_tx.into_iter().collect();
+
+        trace!(%source, "link metric rx stats: {:#?}", node.device_data.link_metric_rx);
+        trace!(%source, "link metric tx stats: {:#?}", node.device_data.link_metric_tx);
     }
 
     pub async fn handle_ap_auto_config_response(


### PR DESCRIPTION
```
Parameter  1:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.LocalInterface
              Type  : string
              Value : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.Interface.0
Parameter  2:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.NeighborDeviceId
              Type  : string
              Value : 02:03:00:4f:ed:60
Parameter  3:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.MetricNumberOfEntries
              Type  : uint32
              Value : 2
Parameter  4:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.0.NeighborMACAddress
              Type  : string
              Value : 02:03:00:4f:ed:60
Parameter  5:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.0.PacketErrorsReceived
              Type  : uint32
              Value : 0
Parameter  6:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.0.PacketsReceived
              Type  : uint32
              Value : 8181
Parameter  7:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.0.RSSI
              Type  : int8
              Value : -1
Parameter  8:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.1.NeighborMACAddress
              Type  : string
              Value : 02:03:00:4f:ed:60
Parameter  9:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.1.IEEE802dot1Bridge
              Type  : boolean
              Value : true
Parameter 10:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.1.PacketErrors
              Type  : uint32
              Value : 0
Parameter 11:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.1.TransmittedPackets
              Type  : uint32
              Value : 3767
Parameter 12:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.1.MACThroughputCapacity
              Type  : uint16
              Value : 0
Parameter 13:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.1.LinkAvailability
              Type  : uint16
              Value : 100
Parameter 14:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.0.IEEE1905Neighbor.0.Metric.1.PHYRate
              Type  : uint16
              Value : 0
```