### PR TITLE
[#406] TR-181 v2-21 - updated `MACAddress` format

### DIFF
--- a/ieee1905-core/src/rbus.rs
+++ b/ieee1905-core/src/rbus.rs
@@ -12,7 +12,6 @@ use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingT
 use crate::rbus::nt_device_bridge_list::RBus_NetworkTopology_Ieee1905Device_BridgingTuple_InterfaceList;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use anyhow::bail;
-use pnet::datalink::MacAddr;
 use rbus_core::{RBusError, RBusLibrary, RBusLogHandler, RBusLogLevel, RBusLogRecord};
 use rbus_provider::element::RBusProviderElement;
 use rbus_provider::element::object::rbus_object;
@@ -131,10 +130,6 @@ impl RBusConnection {
 
 fn peek_topology_database() -> Result<&'static Arc<TopologyDatabase>, RBusError> {
     TopologyDatabase::peek_instance_sync().ok_or(RBusError::NotInitialized)
-}
-
-fn format_mac_address(mac: &MacAddr) -> String {
-    mac.octets().map(|e| format!("{e:02X}")).join("-")
 }
 
 fn format_media_type(media_type: MediaType) -> &'static str {

--- a/ieee1905-core/src/rbus/al_device.rs
+++ b/ieee1905-core/src/rbus/al_device.rs
@@ -1,4 +1,4 @@
-use crate::rbus::{format_mac_address, peek_topology_database};
+use crate::rbus::peek_topology_database;
 use nom::AsBytes;
 use rbus_core::RBusError;
 use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
@@ -18,7 +18,7 @@ impl RBusProviderGetter for RBus_Al_Device {
 
         match args.path_name.as_bytes() {
             b"IEEE1905Id" => {
-                args.property.set(&format_mac_address(&db.al_mac_address));
+                args.property.set(&db.al_mac_address.to_string());
                 Ok(())
             }
             b"InterfaceNumberOfEntries" => {

--- a/ieee1905-core/src/rbus/interface.rs
+++ b/ieee1905-core/src/rbus/interface.rs
@@ -1,5 +1,5 @@
 use crate::rbus::interface_link::RBus_InterfaceLink;
-use crate::rbus::{format_mac_address, format_media_type, peek_topology_database};
+use crate::rbus::{format_media_type, peek_topology_database};
 use nom::AsBytes;
 use rbus_core::RBusError;
 use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
@@ -40,7 +40,7 @@ impl RBusProviderGetter for RBus_Interface {
 
         match args.path_name.as_bytes() {
             b"InterfaceId" => {
-                args.property.set(&format_mac_address(&interface.mac));
+                args.property.set(&interface.mac.to_string());
                 Ok(())
             }
             b"MediaType" => {

--- a/ieee1905-core/src/rbus/interface_link.rs
+++ b/ieee1905-core/src/rbus/interface_link.rs
@@ -1,5 +1,5 @@
 use crate::TopologyDatabase;
-use crate::rbus::{format_mac_address, format_media_type, peek_topology_database};
+use crate::rbus::{format_media_type, peek_topology_database};
 use crate::topology_manager::{
     Ieee1905DeviceData, Ieee1905InterfaceData, Ieee1905LocalInterface, Ieee1905NodeInternal,
 };
@@ -79,12 +79,12 @@ impl RBusProviderGetter for RBus_InterfaceLink {
 
         match args.path_name.as_bytes() {
             b"IEEE1905Id" => {
-                args.property.set(&format_mac_address(&link.al_mac));
+                args.property.set(&link.al_mac.to_string());
                 Ok(())
             }
             b"InterfaceId" => {
                 match link.destination_mac {
-                    Some(e) => args.property.set(&format_mac_address(&e)),
+                    Some(e) => args.property.set(&e.to_string()),
                     None => return Err(RBusError::ElementDoesNotExists),
                 }
                 Ok(())

--- a/ieee1905-core/src/rbus/nt_device.rs
+++ b/ieee1905-core/src/rbus/nt_device.rs
@@ -2,7 +2,7 @@ use crate::TopologyDatabase;
 use crate::cmdu_codec::{DeviceIdentificationType, Ieee1905ProfileVersion, SupportedFreqBand};
 use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingTuple;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
-use crate::rbus::{format_mac_address, peek_topology_database};
+use crate::rbus::peek_topology_database;
 use crate::topology_manager::{
     Ieee1905InterfaceData, Ieee1905LocalInterface, Ieee1905NodeInternal,
 };
@@ -55,11 +55,11 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
             b"IEEE1905Id" => {
                 let al_mac_str = match node {
                     RBus_Ieee1905Device_Node::Local(_) => {
-                        let mac = format_mac_address(&db.local_mac.blocking_read());
-                        format!("{mac}-local",)
+                        let mac = db.local_mac.blocking_read();
+                        format!("{mac}-local")
                     }
                     RBus_Ieee1905Device_Node::Remote(e) => {
-                        format_mac_address(&e.device_data.al_mac)
+                        e.device_data.al_mac.to_string()
                     }
                 };
                 args.property.set(&al_mac_str);

--- a/ieee1905-core/src/rbus/nt_device_non_ieee1905_neighbor.rs
+++ b/ieee1905-core/src/rbus/nt_device_non_ieee1905_neighbor.rs
@@ -1,5 +1,5 @@
 use crate::rbus::nt_device::RBus_Ieee1905Device_Node;
-use crate::rbus::{format_mac_address, peek_topology_database};
+use crate::rbus::peek_topology_database;
 use nom::AsBytes;
 use pnet::datalink::MacAddr;
 use rbus_core::RBusError;
@@ -60,7 +60,7 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neigh
                 Ok(())
             }
             b"NeighborInterfaceId" => {
-                args.property.set(&format_mac_address(&neighbour));
+                args.property.set(&neighbour.to_string());
                 Ok(())
             }
             _ => Err(RBusError::ElementDoesNotExists),


### PR DESCRIPTION
MAC format was incorrectly using `-` instead of `:`. From TR-181 docs:
```
All MAC addresses are represented as strings of 12 hexadecimal digits (digits 0-9, letters A-F or a-f) displayed as six pairs of digits separated by colons.

([0-9A-Fa-f][0-9A-Fa-f]:){5}([0-9A-Fa-f][0-9A-Fa-f])
```