### PR TITLE
[#406] Add L2 Neighbor Device TLV & TR-181 support

### DIFF
--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -25,7 +25,7 @@ use nom::{
     IResult, Parser,
     bytes::complete::take,
     error::{Error, ErrorKind},
-    number::complete::{be_i8, be_u16, be_u32, be_u8},
+    number::complete::{be_i8, be_u8, be_u16, be_u32},
 };
 
 // Internal modules
@@ -172,6 +172,7 @@ pub enum IEEE1905TLVType {
     DeviceIdentificationType,
     ControlUrl,
     Ieee1905ProfileVersion,
+    L2NeighborDevice,
     SupportedService,
     ClientAssociation,
     MultiApProfile,
@@ -205,6 +206,7 @@ impl IEEE1905TLVType {
             0x15 => IEEE1905TLVType::DeviceIdentificationType,
             0x16 => IEEE1905TLVType::ControlUrl,
             0x1a => IEEE1905TLVType::Ieee1905ProfileVersion,
+            0x1e => IEEE1905TLVType::L2NeighborDevice,
             0x80 => IEEE1905TLVType::SupportedService,
             0x92 => IEEE1905TLVType::ClientAssociation,
             0xb3 => IEEE1905TLVType::MultiApProfile,
@@ -238,6 +240,7 @@ impl IEEE1905TLVType {
             IEEE1905TLVType::DeviceIdentificationType => 0x15,
             IEEE1905TLVType::ControlUrl => 0x16,
             IEEE1905TLVType::Ieee1905ProfileVersion => 0x1a,
+            IEEE1905TLVType::L2NeighborDevice => 0x1e,
             IEEE1905TLVType::SupportedService => 0x80,
             IEEE1905TLVType::ClientAssociation => 0x92,
             IEEE1905TLVType::MultiApProfile => 0xb3,
@@ -882,19 +885,107 @@ impl TLVTrait for Ieee1905NeighborDevice {
         let (input, neighborhood_list) =
             all_consuming(many0(IEEE1905Neighbor::parse)).parse(input)?;
 
-        Ok((
-            input,
-            Ieee1905NeighborDevice {
-                local_mac_address,
-                neighborhood_list,
-            },
-        ))
+        let this = Ieee1905NeighborDevice {
+            local_mac_address,
+            neighborhood_list,
+        };
+
+        Ok((input, this))
     }
 
     fn serialize(&self) -> Vec<u8> {
         let mut bytes = Vec::new();
         bytes.extend(self.local_mac_address.octets());
         bytes.extend(self.neighborhood_list.iter().flat_map(|e| e.serialize()));
+        bytes
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct L2NeighborDevice {
+    pub local_interfaces: Vec<L2NeighborLocalInterface>,
+}
+
+impl TLVTrait for L2NeighborDevice {
+    const TYPE: IEEE1905TLVType = IEEE1905TLVType::L2NeighborDevice;
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, local_interfaces_len) = be_u8(input)?;
+        let (input, local_interfaces) = all_consuming(count(
+            L2NeighborLocalInterface::parse,
+            local_interfaces_len as usize,
+        ))
+        .parse(input)?;
+
+        Ok((input, Self { local_interfaces }))
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend((self.local_interfaces.len() as u8).to_be_bytes());
+        bytes.extend(self.local_interfaces.iter().flat_map(|e| e.serialize()));
+        bytes
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct L2NeighborLocalInterface {
+    pub mac_address: MacAddr,
+    pub neighbors: Vec<L2Neighbor>,
+}
+
+impl L2NeighborLocalInterface {
+    pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, mac_address) = take_mac_addr(input)?;
+        let (input, neighbors_len) = be_u16(input)?;
+        let (input, neighbors) = count(L2Neighbor::parse, neighbors_len as usize).parse(input)?;
+
+        let this = Self {
+            mac_address,
+            neighbors,
+        };
+
+        Ok((input, this))
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend(self.mac_address.octets());
+        bytes.extend((self.neighbors.len() as u16).to_be_bytes());
+        bytes.extend(self.neighbors.iter().flat_map(|e| e.serialize()));
+        bytes
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct L2Neighbor {
+    pub mac_address: MacAddr,
+    pub behind_mac_addresses: Vec<MacAddr>,
+}
+
+impl L2Neighbor {
+    pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        let (input, mac_address) = take_mac_addr(input)?;
+        let (input, behind_mac_addresses_len) = be_u16(input)?;
+        let (input, behind_mac_addresses) =
+            count(take_mac_addr, behind_mac_addresses_len as usize).parse(input)?;
+
+        let this = Self {
+            mac_address,
+            behind_mac_addresses,
+        };
+
+        Ok((input, this))
+    }
+
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend(self.mac_address.octets());
+        bytes.extend((self.behind_mac_addresses.len() as u16).to_be_bytes());
+        bytes.extend(self.behind_mac_addresses.iter().flat_map(|e| e.octets()));
         bytes
     }
 }
@@ -2513,18 +2604,9 @@ pub mod tests {
             IEEE1905TLVType::from_u8(0x10),
             IEEE1905TLVType::SupportedFreqBand
         );
-        assert_eq!(
-            IEEE1905TLVType::from_u8(0x16),
-            IEEE1905TLVType::ControlUrl
-        );
-        assert_eq!(
-            IEEE1905TLVType::from_u8(0x17),
-            IEEE1905TLVType::Ipv4
-        );
-        assert_eq!(
-            IEEE1905TLVType::from_u8(0x18),
-            IEEE1905TLVType::Ipv6
-        );
+        assert_eq!(IEEE1905TLVType::from_u8(0x16), IEEE1905TLVType::ControlUrl);
+        assert_eq!(IEEE1905TLVType::from_u8(0x17), IEEE1905TLVType::Ipv4);
+        assert_eq!(IEEE1905TLVType::from_u8(0x18), IEEE1905TLVType::Ipv6);
         assert_eq!(
             IEEE1905TLVType::from_u8(0x14),
             IEEE1905TLVType::GenericPhyDeviceInformation
@@ -2536,6 +2618,10 @@ pub mod tests {
         assert_eq!(
             IEEE1905TLVType::from_u8(0x1a),
             IEEE1905TLVType::Ieee1905ProfileVersion
+        );
+        assert_eq!(
+            IEEE1905TLVType::from_u8(0x1e),
+            IEEE1905TLVType::L2NeighborDevice
         );
         assert_eq!(
             IEEE1905TLVType::from_u8(0x80),
@@ -2929,6 +3015,68 @@ pub mod tests {
         assert_eq!(parsed_device.neighborhood_list.len(), 0);
     }
 
+    // Verify serializing and parsing L2 neighbor device
+    #[test]
+    fn test_l2_neighbor_device_parse_and_serialize() {
+        let input = [
+            0x02, // local interface count: 2
+            0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, // local interface MAC: aa:bb:cc:dd:ee:ff
+            0x00, 0x02, // L2 neighbor device count: 2
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, // L2 neighbor MAC: 11:22:33:44:55:66
+            0x00, 0x02, // behind MAC address count: 2
+            0x21, 0x22, 0x23, 0x24, 0x25, 0x26, // behind MAC address: 21:22:23:24:25:26
+            0x31, 0x32, 0x33, 0x34, 0x35, 0x36, // behind MAC address: 31:32:33:34:35:36
+            0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, // L2 neighbor MAC: 77:88:99:aa:bb:cc
+            0x00, 0x00, // behind MAC address count: 0
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, // local interface MAC: 00:11:22:33:44:55
+            0x00, 0x00, // L2 neighbor device count: 0
+        ];
+        let expected = L2NeighborDevice {
+            local_interfaces: vec![
+                L2NeighborLocalInterface {
+                    mac_address: MacAddr::new(0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF),
+                    neighbors: vec![
+                        L2Neighbor {
+                            mac_address: MacAddr::new(0x11, 0x22, 0x33, 0x44, 0x55, 0x66),
+                            behind_mac_addresses: vec![
+                                MacAddr::new(0x21, 0x22, 0x23, 0x24, 0x25, 0x26),
+                                MacAddr::new(0x31, 0x32, 0x33, 0x34, 0x35, 0x36),
+                            ],
+                        },
+                        L2Neighbor {
+                            mac_address: MacAddr::new(0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC),
+                            behind_mac_addresses: vec![],
+                        },
+                    ],
+                },
+                L2NeighborLocalInterface {
+                    mac_address: MacAddr::new(0x00, 0x11, 0x22, 0x33, 0x44, 0x55),
+                    neighbors: vec![],
+                },
+            ],
+        };
+
+        let (remaining, parsed) = L2NeighborDevice::parse(&input).unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(parsed, expected);
+        assert_eq!(parsed.serialize(), input);
+    }
+
+    // Verify L2 neighbor device parser rejects trailing bytes inside TLV value
+    #[test]
+    fn test_l2_neighbor_device_parse_rejects_trailing_bytes() {
+        let mut serialized = L2NeighborDevice {
+            local_interfaces: vec![L2NeighborLocalInterface {
+                mac_address: MacAddr::new(0x00, 0x11, 0x22, 0x33, 0x44, 0x55),
+                neighbors: vec![],
+            }],
+        }
+        .serialize();
+        serialized.push(0x00);
+
+        assert!(L2NeighborDevice::parse(&serialized).is_err());
+    }
+
     // Verify parsing and serializing vendor specific info
     #[test]
     fn test_vendor_specific_info_parse_and_serialize() {
@@ -3201,6 +3349,7 @@ pub mod tests {
         device_id[64..76].copy_from_slice(b"Manufacturer");
         device_id[128..137].copy_from_slice(b"ModelName");
 
+        #[rustfmt::skip]
         let input: Vec<u8> = [
             [0x00, 0x00, 0x00, 0x0E, 0xDB, 0x9E, 0x00, 0x80].as_slice(), // CMDU header
             &[0x01, 0x00, 0x06, 0x02, 0x42, 0xC0, 0xA8, 0x64, 0x02], // AlMacAddress TLV

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -538,11 +538,13 @@ impl CMDUHandler {
         }
 
         let remote_al_mac = node.device_data.al_mac;
+        let l2_neighbor_devices = L2NeighborDevice::find_all(tlvs).collect();
         let updated_device_data = Ieee1905DeviceData {
             al_mac: remote_al_mac,
             destination_frame_mac: source_mac,
             local_interface_mac,
             local_interface_list: Some(interfaces.clone()),
+            l2_neighbor_devices,
             ..Default::default()
         };
 

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -320,6 +320,7 @@ async fn inject_topology_response_tlvs(
         DeviceBridgingCapability::TYPE.to_u8(),
         Ieee1905NeighborDevice::TYPE.to_u8(),
         NonIeee1905NeighborDevices::TYPE.to_u8(),
+        L2NeighborDevice::TYPE.to_u8(),
         Ipv6::TYPE.to_u8(),
     ];
     vec.retain(|e| !filtered_types.contains(&e.tlv_type));
@@ -407,6 +408,51 @@ async fn inject_topology_response_tlvs(
                 neighborhood_list: neighbors.to_owned(),
             }))
         }));
+    }
+
+    // injecting L2NeighborDevice
+    {
+        let local_interfaces = db.local_interface_list.read().await;
+        let local_interface_list = local_interfaces.as_deref().unwrap_or_default();
+        let local_interface_list = local_interface_list
+            .iter()
+            .filter_map(|e| {
+                let ieee1905_neighbors =
+                    e.ieee1905_neighbors
+                        .iter()
+                        .flatten()
+                        .map(|neighbor| L2Neighbor {
+                            mac_address: neighbor.neighbor_al_mac,
+                            behind_mac_addresses: Vec::new(),
+                        });
+
+                let non_ieee1905_neighbors =
+                    e.non_ieee1905_neighbors
+                        .iter()
+                        .flatten()
+                        .map(|neighbor| L2Neighbor {
+                            mac_address: *neighbor,
+                            behind_mac_addresses: Vec::new(),
+                        });
+
+                let neighbor_interface = L2NeighborLocalInterface {
+                    mac_address: e.mac,
+                    neighbors: ieee1905_neighbors.chain(non_ieee1905_neighbors).collect(),
+                };
+
+                if neighbor_interface.neighbors.is_empty() {
+                    None
+                } else {
+                    Some(neighbor_interface)
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if !local_interface_list.is_empty() {
+            vec.push(TLV::from(L2NeighborDevice {
+                local_interfaces: local_interface_list,
+            }));
+        }
     }
 
     // injecting VendorInfo
@@ -982,6 +1028,16 @@ mod tests {
             MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x02, 0x02),
             MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x02, 0x03),
         ]);
+        if1.data.ieee1905_neighbors = Some(vec![
+            IEEE1905Neighbor {
+                neighbor_al_mac: MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x03, 0x01),
+                neighbor_flags: 0,
+            },
+            IEEE1905Neighbor {
+                neighbor_al_mac: MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x03, 0x02),
+                neighbor_flags: 0,
+            },
+        ]);
 
         let mut if2 = Ieee1905LocalInterface::default();
         if2.data.mac = MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x00, 0x02);
@@ -1041,6 +1097,18 @@ mod tests {
         assert_eq!(
             non_ieee1905_list.neighborhood_list,
             if1.non_ieee1905_neighbors.as_deref().unwrap_or_default()
+        );
+
+        let l2_neighbor_device = L2NeighborDevice::find(&vec).unwrap();
+        let l2_neighbor_device_if = &l2_neighbor_device.local_interfaces[0];
+        assert_eq!(l2_neighbor_device_if.mac_address, if1.mac);
+        assert_eq!(
+            l2_neighbor_device_if.neighbors[0].mac_address,
+            MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x03, 0x01)
+        );
+        assert_eq!(
+            l2_neighbor_device_if.neighbors[2].mac_address,
+            MacAddr::new(0x00, 0x00, 0x00, 0x00, 0x02, 0x01)
         );
 
         let Some(last) = vec.last() else {

--- a/ieee1905-core/src/lib.rs
+++ b/ieee1905-core/src/lib.rs
@@ -52,7 +52,8 @@ pub mod lldpdu {
 pub mod cmdu {
     pub use crate::cmdu_codec::{
         AlMacAddress, BridgingTuple, CMDU, CMDUType, DeviceBridgingCapability, DeviceInformation,
-        IEEE1905Neighbor, IEEE1905TLVType, Ieee1905NeighborDevice, LocalInterface, MacAddress,
+        IEEE1905Neighbor, IEEE1905TLVType, Ieee1905NeighborDevice, L2Neighbor, L2NeighborDevice,
+        L2NeighborLocalInterface, LocalInterface, MacAddress,
         NonIEEE1905LocalInterfaceNeighborhood, NonIEEE1905Neighbor, NonIeee1905NeighborDevices,
         VendorSpecificInfo,
     };

--- a/ieee1905-core/src/rbus.rs
+++ b/ieee1905-core/src/rbus.rs
@@ -19,6 +19,7 @@ use crate::rbus::nt_device_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Devic
 use crate::rbus::nt_device_ieee1905_neighbor_metric::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor_Metric;
 use crate::rbus::nt_device_ipv4::RBus_NetworkTopology_Ieee1905Device_IPv4;
 use crate::rbus::nt_device_ipv6::RBus_NetworkTopology_Ieee1905Device_IPv6;
+use crate::rbus::nt_device_l2_neighbor::RBus_NetworkTopology_Ieee1905Device_L2Neighbor;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use anyhow::bail;
 use rbus_core::{RBusError, RBusLibrary, RBusLogHandler, RBusLogLevel, RBusLogRecord};
@@ -47,6 +48,7 @@ mod nt_device_ieee1905_neighbor;
 mod nt_device_ieee1905_neighbor_metric;
 mod nt_device_ipv4;
 mod nt_device_ipv6;
+mod nt_device_l2_neighbor;
 mod nt_device_non_ieee1905_neighbor;
 
 ///
@@ -135,6 +137,14 @@ impl RBusConnection {
                         rbus_property("FriendlyName", RBus_NetworkTopology_Ieee1905Device),
                         rbus_property("ManufacturerName", RBus_NetworkTopology_Ieee1905Device),
                         rbus_property("ManufacturerModel", RBus_NetworkTopology_Ieee1905Device),
+                    ),
+                    (
+                        rbus_property("L2NeighborNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),
+                        rbus_table("L2Neighbor", RBus_NetworkTopology_Ieee1905Device_L2Neighbor, (
+                            rbus_property("LocalInterface", RBus_NetworkTopology_Ieee1905Device_L2Neighbor),
+                            rbus_property("NeighborInterfaceId", RBus_NetworkTopology_Ieee1905Device_L2Neighbor),
+                            rbus_property("BehindInterfaceIds", RBus_NetworkTopology_Ieee1905Device_L2Neighbor),
+                        )),
                     ),
                     (
                         rbus_property("BridgingTupleNumberOfEntries", RBus_NetworkTopology_Ieee1905Device),

--- a/ieee1905-core/src/rbus/nt_device.rs
+++ b/ieee1905-core/src/rbus/nt_device.rs
@@ -6,6 +6,7 @@ use crate::rbus::nt_device_bridge::RBus_NetworkTopology_Ieee1905Device_BridgingT
 use crate::rbus::nt_device_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_IEEE1905Neighbor;
 use crate::rbus::nt_device_ipv4::RBus_NetworkTopology_Ieee1905Device_IPv4;
 use crate::rbus::nt_device_ipv6::RBus_NetworkTopology_Ieee1905Device_IPv6;
+use crate::rbus::nt_device_l2_neighbor::RBus_NetworkTopology_Ieee1905Device_L2Neighbor;
 use crate::rbus::nt_device_non_ieee1905_neighbor::RBus_NetworkTopology_Ieee1905Device_NonIEEE1905Neighbor;
 use crate::rbus::peek_topology_database;
 use crate::topology_manager::{
@@ -27,6 +28,7 @@ use tokio::sync::RwLockReadGuard;
 /// - FriendlyName
 /// - ManufacturerName
 /// - ManufacturerModel
+/// - L2NeighborNumberOfEntries
 /// - BridgingTupleNumberOfEntries
 /// - IEEE1905NeighborNumberOfEntries
 /// - NonIEEE1905NeighborNumberOfEntries
@@ -72,7 +74,7 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
                 Ok(())
             }
             b"Version" => {
-                let value = match node.ieee1905profile_version().unwrap_or_default() {
+                let value = match node.ieee1905profile_version() {
                     Ieee1905ProfileVersion::Ieee1905_1 => Cow::Borrowed("1905.1"),
                     Ieee1905ProfileVersion::Ieee1905_1a => Cow::Borrowed("1905.1a"),
                     Ieee1905ProfileVersion::Reserved(e) => format!("unknown({e})").into(),
@@ -113,6 +115,11 @@ impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device {
                     Some(e) => &e.manufacturer_model,
                 };
                 args.property.set(value);
+                Ok(())
+            }
+            b"L2NeighborNumberOfEntries" => {
+                let iter = RBus_NetworkTopology_Ieee1905Device_L2Neighbor::iter(&node);
+                args.property.set(&(iter.count() as u32));
                 Ok(())
             }
             b"BridgingTupleNumberOfEntries" => {
@@ -172,10 +179,10 @@ impl<'a> RBus_Ieee1905Device_Node<'a> {
         }
     }
 
-    pub fn ieee1905profile_version(&self) -> Option<Ieee1905ProfileVersion> {
+    pub fn ieee1905profile_version(&self) -> Ieee1905ProfileVersion {
         match self {
-            RBus_Ieee1905Device_Node::Local(_) => Some(Ieee1905ProfileVersion::Ieee1905_1),
-            RBus_Ieee1905Device_Node::Remote(e) => Some(e.device_data.ieee1905_profile_version),
+            RBus_Ieee1905Device_Node::Local(_) => Ieee1905ProfileVersion::Ieee1905_1,
+            RBus_Ieee1905Device_Node::Remote(e) => e.device_data.ieee1905_profile_version,
         }
     }
 

--- a/ieee1905-core/src/rbus/nt_device_l2_neighbor.rs
+++ b/ieee1905-core/src/rbus/nt_device_l2_neighbor.rs
@@ -1,0 +1,112 @@
+use crate::rbus::nt_device::RBus_Ieee1905Device_Node;
+use crate::rbus::peek_topology_database;
+use either::Either;
+use nom::AsBytes;
+use pnet::datalink::MacAddr;
+use rbus_core::RBusError;
+use rbus_provider::element::property::{RBusProviderGetter, RBusProviderGetterArgs};
+use rbus_provider::element::table::{RBusProviderTableSync, RBusProviderTableSyncArgs};
+
+///
+/// Device.IEEE1905.AL.NetworkTopology.IEEE1905Device.{i}.L2Neighbor.{i}.
+/// - LocalInterface
+/// - NeighborInterfaceId
+/// - BehindInterfaceIds
+///
+pub struct RBus_NetworkTopology_Ieee1905Device_L2Neighbor;
+
+pub struct L2Neighbor<'a> {
+    local_if_mac: MacAddr,
+    neighbor_if_mac: MacAddr,
+    behind_if_macs: &'a [MacAddr],
+}
+
+impl RBus_NetworkTopology_Ieee1905Device_L2Neighbor {
+    pub fn iter<'a>(node: &'a RBus_Ieee1905Device_Node) -> impl Iterator<Item = L2Neighbor<'a>> {
+        match node {
+            RBus_Ieee1905Device_Node::Local(e) => Either::Left(e.iter().flat_map(|e| {
+                let ieee1905_neighbors =
+                    e.ieee1905_neighbors
+                        .iter()
+                        .flatten()
+                        .map(|neighbor| L2Neighbor {
+                            local_if_mac: e.mac,
+                            neighbor_if_mac: neighbor.neighbor_al_mac,
+                            behind_if_macs: &[],
+                        });
+
+                let non_ieee1905_neighbors =
+                    e.non_ieee1905_neighbors
+                        .iter()
+                        .flatten()
+                        .map(|neighbor| L2Neighbor {
+                            local_if_mac: e.mac,
+                            neighbor_if_mac: *neighbor,
+                            behind_if_macs: &[],
+                        });
+
+                ieee1905_neighbors.chain(non_ieee1905_neighbors)
+            })),
+            RBus_Ieee1905Device_Node::Remote(node) => Either::Right(
+                node.device_data
+                    .l2_neighbor_devices
+                    .iter()
+                    .flat_map(|e| e.local_interfaces.iter())
+                    .flat_map(|e| {
+                        e.neighbors.iter().map(|neighbor| L2Neighbor {
+                            local_if_mac: e.mac_address,
+                            neighbor_if_mac: neighbor.mac_address,
+                            behind_if_macs: &neighbor.behind_mac_addresses,
+                        })
+                    }),
+            ),
+        }
+    }
+}
+
+impl RBusProviderTableSync for RBus_NetworkTopology_Ieee1905Device_L2Neighbor {
+    type UserData = ();
+
+    fn len(&mut self, args: RBusProviderTableSyncArgs<Self::UserData>) -> Result<u32, RBusError> {
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+        let count = Self::iter(&node).count();
+
+        Ok(count as u32)
+    }
+}
+
+impl RBusProviderGetter for RBus_NetworkTopology_Ieee1905Device_L2Neighbor {
+    type UserData = ();
+
+    fn get(&mut self, args: RBusProviderGetterArgs<Self::UserData>) -> Result<(), RBusError> {
+        let Some(neighbour_index) = args.table_idx.get(1).copied() else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        let db = peek_topology_database()?;
+        let node = RBus_Ieee1905Device_Node::from(db, args.table_idx)?.1;
+        let mut neighbours = Self::iter(&node);
+
+        let Some(neighbour) = neighbours.nth(neighbour_index as usize) else {
+            return Err(RBusError::ElementDoesNotExists);
+        };
+
+        match args.path_name.as_bytes() {
+            b"LocalInterface" => {
+                args.property.set(&neighbour.local_if_mac.to_string());
+                Ok(())
+            }
+            b"NeighborInterfaceId" => {
+                args.property.set(&neighbour.neighbor_if_mac.to_string());
+                Ok(())
+            }
+            b"BehindInterfaceIds" => {
+                let macs = Vec::from_iter(neighbour.behind_if_macs.iter().map(|e| e.to_string()));
+                args.property.set(&macs.join(","));
+                Ok(())
+            }
+            _ => Err(RBusError::ElementDoesNotExists),
+        }
+    }
+}

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -40,6 +40,7 @@ use crate::{
     spawn_named,
 };
 
+use crate::cmdu::L2NeighborDevice;
 #[cfg(feature = "topology_ui")]
 use crossterm::{
     event::EventStream,
@@ -366,6 +367,7 @@ pub struct Ieee1905DeviceData {
     pub ipv6: Option<Ipv6>,
     pub link_metric_rx: Vec<LinkMetricRx>,
     pub link_metric_tx: Vec<LinkMetricTx>,
+    pub l2_neighbor_devices: Vec<L2NeighborDevice>,
 }
 
 impl Ieee1905DeviceData {
@@ -904,6 +906,10 @@ impl TopologyDatabase {
                                     Some(StateLocal::ConvergedLocal),
                                     None,
                                 );
+
+                                node.device_data
+                                    .l2_neighbor_devices
+                                    .clone_from(&device_data.l2_neighbor_devices);
 
                                 debug!(
                                     current_local_interface_list = ?node.device_data.local_interface_list,


### PR DESCRIPTION
```
Parameter  1:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.L2Neighbor.0.LocalInterface
              Type  : string
              Value : 02:01:01:4f:ed:52
Parameter  2:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.L2Neighbor.0.NeighborInterfaceId
              Type  : string
              Value : 90:9a:4a:ea:66:9d
Parameter  3:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.L2Neighbor.0.BehindInterfaceIds
              Type  : string
              Value :
Parameter  4:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.L2Neighbor.1.LocalInterface
              Type  : string
              Value : 02:01:01:4f:ed:52
Parameter  5:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.L2Neighbor.1.NeighborInterfaceId
              Type  : string
              Value : 52:55:55:21:aa:0b
Parameter  6:
              Name  : Device.IEEE1905.AL.0.NetworkTopology.IEEE1905Device.1.L2Neighbor.1.BehindInterfaceIds
              Type  : string
              Value :
```

<img width="726" height="563" alt="image" src="https://github.com/user-attachments/assets/d311348e-a93b-4ff0-98d8-9ea84b7415d5" />

[l2_neighbors.pcapng.zip](https://github.com/user-attachments/files/29740941/l2_neighbors.pcapng.zip)