### PR TITLE
[#407] Add Generic PHY query and response handling

### DIFF
--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -2040,8 +2040,10 @@ pub struct GenericPhyDeviceInformation {
     pub local_interfaces: Vec<GenericPhyLocalInterface>,
 }
 
-impl GenericPhyDeviceInformation {
-    pub fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+impl TLVTrait for GenericPhyDeviceInformation {
+    const TYPE: IEEE1905TLVType = IEEE1905TLVType::GenericPhyDeviceInformation;
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
         let (input, al_mac) = take_mac_addr(input)?;
         let (input, local_interfaces) =
             all_consuming(length_count(be_u8, GenericPhyLocalInterface::parse)).parse(input)?;
@@ -2054,7 +2056,7 @@ impl GenericPhyDeviceInformation {
         Ok((input, this))
     }
 
-    pub fn serialize(&self) -> Vec<u8> {
+    fn serialize(&self) -> Vec<u8> {
         let mut vec = Vec::new();
         vec.extend(self.al_mac.octets());
         vec.extend((self.local_interfaces.len() as u8).to_be_bytes());
@@ -3391,6 +3393,64 @@ pub mod tests {
         assert!(remaining.is_empty());
         assert_eq!(parsed.message_type, CMDUType::HigherLayerResponse.to_u16());
         assert_eq!(parsed.message_id, 0xDB9E);
+        assert_eq!(parsed.fragment, 0);
+        assert_eq!(parsed.flags, 0x80);
+        assert_eq!(parsed.serialize(), input);
+    }
+
+    // Verify parsing and serializing of GenericPhyQuery CMDU
+    #[test]
+    fn test_generic_phy_query_cmdu_parse_and_serialize() {
+        let input = [
+            0x00, 0x00, // message_version, reserved
+            0x00, 0x11, // message_type: GenericPhyQuery
+            0xDB, 0x9F, // message_id
+            0x00, 0x80, // fragment, flags
+            0x00, 0x00, 0x00, // EndOfMessage TLV
+        ];
+
+        let (remaining, parsed) = CMDU::parse(&input).unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(parsed.message_type, CMDUType::GenericPhyQuery.to_u16());
+        assert_eq!(parsed.message_id, 0xDB9F);
+        assert_eq!(parsed.fragment, 0);
+        assert_eq!(parsed.flags, 0x80);
+        assert_eq!(parsed.payload, &[0x00, 0x00, 0x00]);
+        assert_eq!(parsed.serialize(), input);
+    }
+
+    // Verify parsing and serializing of GenericPhyResponse CMDU
+    #[test]
+    fn test_generic_phy_response_cmdu_parse_and_serialize() {
+        let mut variant_name = [0u8; 32];
+        variant_name[..10].copy_from_slice(b"GenericPHY");
+
+        let input: Vec<u8> = [
+            [0x00, 0x00, 0x00, 0x12, 0xDB, 0x9F, 0x00, 0x80].as_slice(), // CMDU header
+            &[
+                0x14, 0x00, 0x4A, // TLV: GenericPhyDeviceInformation
+                0x02, 0x42, 0xC0, 0xA8, 0x64, 0x02, // AL MAC address
+                0x01, // local interface count
+                0x02, 0x42, 0xC0, 0xA8, 0x64, 0x03, // local interface MAC
+                0x00, 0x11, 0x22, // OUI
+                0x07, // variant index
+            ],
+            variant_name.as_slice(),
+            &[
+                0x14, // XML URL length
+                0x03, // media specific info length
+                b'h', b't', b't', b'p', b':', b'/', b'/', b't', b'e', b's', b't', b'.', b'c', b'o',
+                b'm', b'/', b't', b'e', b's', b't', // XML URL: http://test.com/test
+                0xAA, 0xBB, 0xCC, // media specific info: AA BB CC
+                0x00, 0x00, 0x00, // EndOfMessage TLV
+            ],
+        ]
+        .concat();
+
+        let (remaining, parsed) = CMDU::parse(&input).unwrap();
+        assert!(remaining.is_empty());
+        assert_eq!(parsed.message_type, CMDUType::GenericPhyResponse.to_u16());
+        assert_eq!(parsed.message_id, 0xDB9F);
         assert_eq!(parsed.fragment, 0);
         assert_eq!(parsed.flags, 0x80);
         assert_eq!(parsed.serialize(), input);

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -213,6 +213,16 @@ impl CMDUHandler {
                     .handle_higher_layer_response(&tlvs, message_id, source_mac)
                     .await;
             }
+            CMDUType::GenericPhyQuery => {
+                handled = self
+                    .handle_generic_phy_query(&tlvs, message_id, source_mac)
+                    .await;
+            }
+            CMDUType::GenericPhyResponse => {
+                handled = self
+                    .handle_generic_phy_response(&tlvs, message_id, source_mac)
+                    .await;
+            }
             _ => handled = false,
         };
 
@@ -309,6 +319,20 @@ impl CMDUHandler {
                 spawn_named(
                     format!("proxy_hle_query/{destination}"),
                     cmdu_higher_layer_query_transmission_worker(
+                        topology_db.clone(),
+                        self.sender.clone(),
+                        self.message_id_generator.clone(),
+                        forwarding_interface_mac,
+                        destination,
+                        token,
+                    ),
+                );
+            }
+            TransmissionEvent::StartGenericPhyQueryWorker((destination, token)) => {
+                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                spawn_named(
+                    format!("proxy_generic_phy_query/{destination}"),
+                    cmdu_generic_phy_query_transmission_worker(
                         topology_db.clone(),
                         self.sender.clone(),
                         self.message_id_generator.clone(),
@@ -586,6 +610,21 @@ impl CMDUHandler {
                     ),
                 );
                 true
+            }
+            TransmissionEvent::StartGenericPhyQueryWorker((destination, token)) => {
+                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                spawn_named(
+                    format!("proxy_generic_phy_query/{destination}"),
+                    cmdu_generic_phy_query_transmission_worker(
+                        topology_db.clone(),
+                        self.sender.clone(),
+                        self.message_id_generator.clone(),
+                        forwarding_interface_mac,
+                        destination,
+                        token,
+                    ),
+                );
+                false
             }
             TransmissionEvent::None => {
                 debug!(
@@ -952,6 +991,97 @@ impl CMDUHandler {
 
         info!(source = %source_mac, "HigherLayerResponse Processed");
         result
+    }
+
+    #[instrument(skip_all, name = "generic_phy_query")]
+    async fn handle_generic_phy_query(
+        &self,
+        tlvs: &[TLV],
+        message_id: u16,
+        source_mac: MacAddr,
+    ) -> bool {
+        debug!(
+            source = %source_mac,
+            msg_id = message_id,
+            interface = self.interface_name,
+            "Handling GenericPhyQuery CMDU",
+        );
+
+        if EndOfMessage::find(tlvs).is_none() {
+            error!("GenericPhyQuery CMDU missing EndOfMessage TLV");
+            return true;
+        }
+
+        let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
+        let Some(node) = topology_db.find_device_by_port(source_mac).await else {
+            warn!(%source_mac, "GenericPhyQuery source node not found");
+            return false;
+        };
+
+        let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+        let remote_al_mac = node.device_data.al_mac;
+
+        spawn_named(
+            format!("proxy_generic_phy_response/{remote_al_mac}"),
+            cmdu_generic_phy_response_transmission(
+                self.interface_name.clone(),
+                self.sender.clone(),
+                self.local_al_mac,
+                remote_al_mac,
+                forwarding_interface_mac,
+                message_id,
+            ),
+        );
+
+        info!(source = %source_mac, "GenericPhyQuery Processed");
+        true
+    }
+
+    #[instrument(skip_all, name = "generic_phy_response")]
+    async fn handle_generic_phy_response(
+        &self,
+        tlvs: &[TLV],
+        message_id: u16,
+        source_mac: MacAddr,
+    ) -> bool {
+        debug!(
+            source = %source_mac,
+            msg_id = message_id,
+            interface = self.interface_name,
+            "Handling GenericPhyResponse CMDU",
+        );
+
+        if EndOfMessage::find(tlvs).is_none() {
+            error!("GenericPhyResponse CMDU missing EndOfMessage TLV");
+            return true;
+        };
+
+        let Some(generic_phy) = GenericPhyDeviceInformation::find(tlvs) else {
+            error!("GenericPhyResponse CMDU missing GenericPhyDeviceInformation TLV");
+            return true;
+        };
+
+        let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
+        let changed = topology_db
+            .handle_generic_phy_response(source_mac, message_id, generic_phy)
+            .await;
+
+        if changed {
+            let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+            spawn_named(
+                "proxy_topo_notification",
+                cmdu_topology_notification_transmission(
+                    self.interface_name.clone(),
+                    self.sender.clone(),
+                    self.message_id_generator.clone(),
+                    self.local_al_mac,
+                    forwarding_interface_mac,
+                ),
+            );
+        }
+
+        info!(source = %source_mac, "GenericPhyResponse Processed");
+        true
     }
 
     #[instrument(skip_all, name = "sdu_from_cmdu")]

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -328,20 +328,6 @@ impl CMDUHandler {
                     ),
                 );
             }
-            TransmissionEvent::StartGenericPhyQueryWorker((destination, token)) => {
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_generic_phy_query/{destination}"),
-                    cmdu_generic_phy_query_transmission_worker(
-                        topology_db.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        forwarding_interface_mac,
-                        destination,
-                        token,
-                    ),
-                );
-            }
             TransmissionEvent::None => {
                 debug!(
                     remote = %remote_al_mac,

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -281,7 +281,7 @@ impl CMDUHandler {
             ..Default::default()
         };
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 device_data,
                 UpdateType::DiscoveryReceived,
@@ -298,44 +298,60 @@ impl CMDUHandler {
             "Topology Discovery Processed",
         );
 
-        // Now react to the event
-        match transmission_event {
-            TransmissionEvent::SendTopologyQuery(destination_al_mac) => {
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_topo_query/{destination_al_mac}"),
-                    cmdu_topology_query_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        self.local_al_mac,
-                        destination_al_mac,
-                        forwarding_interface_mac,
-                    ),
-                );
-            }
-            TransmissionEvent::StartHigherLayerQueryWorker((destination, token)) => {
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_hle_query/{destination}"),
-                    cmdu_higher_layer_query_transmission_worker(
-                        topology_db.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        forwarding_interface_mac,
-                        destination,
-                        token,
-                    ),
-                );
-            }
-            TransmissionEvent::None => {
-                debug!(
-                    remote = %remote_al_mac,
-                    "No transmission needed after topology discovery update"
-                );
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_discovery");
+        if transmission_events.is_empty() {
+            debug!(
+                remote = %remote_al_mac,
+                "No transmission needed after topology discovery update"
+            );
+        }
+
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyQuery(destination_al_mac) => {
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                    spawn_named(
+                        format!("proxy_topo_query/{destination_al_mac}"),
+                        cmdu_topology_query_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            self.local_al_mac,
+                            destination_al_mac,
+                            forwarding_interface_mac,
+                        ),
+                    );
+                }
+                TransmissionEvent::StartHigherLayerQueryWorker((destination, token)) => {
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                    spawn_named(
+                        format!("proxy_hle_query/{destination}"),
+                        cmdu_higher_layer_query_transmission_worker(
+                            topology_db.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            forwarding_interface_mac,
+                            destination,
+                            token,
+                        ),
+                    );
+                }
+                TransmissionEvent::StartGenericPhyQueryWorker((destination, token)) => {
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                    spawn_named(
+                        format!("proxy_generic_phy_query/{destination}"),
+                        cmdu_generic_phy_query_transmission_worker(
+                            topology_db.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            forwarding_interface_mac,
+                            destination,
+                            token,
+                        ),
+                    );
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_discovery");
+                }
             }
         }
     }
@@ -384,7 +400,7 @@ impl CMDUHandler {
         let remote_al_mac = device_data.al_mac;
         let has_vendor_info = VendorSpecificInfo::find(tlvs).is_some_and(|e| e.oui == COMCAST_OUI);
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 device_data,
                 UpdateType::QueryReceived {
@@ -402,41 +418,45 @@ impl CMDUHandler {
             "Topology Query Processed",
         );
 
-        match transmission_event {
-            TransmissionEvent::SendTopologyResponse(destination_mac) => {
-                debug!(
-                    remote = %remote_al_mac,
-                    local = %self.local_al_mac,
-                    "Preparing to send Topology Response"
-                );
+        if transmission_events.is_empty() {
+            debug!(
+                remote = %remote_al_mac,
+                "No transmission needed after topology query update"
+            );
+            return false;
+        }
 
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+        let mut sent_response = false;
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyResponse(destination_mac) => {
+                    debug!(
+                        remote = %remote_al_mac,
+                        local = %self.local_al_mac,
+                        "Preparing to send Topology Response"
+                    );
 
-                spawn_named(
-                    format!("proxy_topo_response/{destination_mac}"),
-                    cmdu_topology_response_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.local_al_mac,
-                        destination_mac,
-                        forwarding_interface_mac,
-                        message_id,
-                    ),
-                );
-                true
-            }
-            TransmissionEvent::None => {
-                debug!(
-                    remote = %remote_al_mac,
-                    "No transmission needed after topology query update"
-                );
-                false
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_query");
-                false
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+
+                    spawn_named(
+                        format!("proxy_topo_response/{destination_mac}"),
+                        cmdu_topology_response_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.local_al_mac,
+                            destination_mac,
+                            forwarding_interface_mac,
+                            message_id,
+                        ),
+                    );
+                    sent_response = true;
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_query");
+                }
             }
         }
+        sent_response
     }
 
     /// Handles and logs TLVs for Topology Response.
@@ -558,7 +578,7 @@ impl CMDUHandler {
             ..Default::default()
         };
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 updated_device_data,
                 UpdateType::ResponseReceived,
@@ -575,56 +595,45 @@ impl CMDUHandler {
             "Topology Response Processed",
         );
 
-        match transmission_event {
-            TransmissionEvent::SendTopologyNotification(_destination_mac) => {
-                debug!(
-                    al_mac = %remote_al_mac,
-                    source = %source_mac,
-                    "Sending Topology Notification because topology changed"
-                );
+        if transmission_events.is_empty() {
+            debug!(
+                al_mac = %remote_al_mac,
+                source = %source_mac,
+                "Topology update did not require sending notification"
+            );
+            return false;
+        }
 
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+        let mut sent_notification = false;
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyNotification(_destination_mac) => {
+                    debug!(
+                        al_mac = %remote_al_mac,
+                        source = %source_mac,
+                        "Sending Topology Notification because topology changed"
+                    );
 
-                spawn_named(
-                    "proxy_topo_notification",
-                    cmdu_topology_notification_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        self.local_al_mac,
-                        forwarding_interface_mac,
-                    ),
-                );
-                true
-            }
-            TransmissionEvent::StartGenericPhyQueryWorker((destination, token)) => {
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_generic_phy_query/{destination}"),
-                    cmdu_generic_phy_query_transmission_worker(
-                        topology_db.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        forwarding_interface_mac,
-                        destination,
-                        token,
-                    ),
-                );
-                false
-            }
-            TransmissionEvent::None => {
-                debug!(
-                    al_mac = %remote_al_mac,
-                    source = %source_mac,
-                    "Topology update did not require sending notification"
-                );
-                false
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_response");
-                false
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+
+                    spawn_named(
+                        "proxy_topo_notification",
+                        cmdu_topology_notification_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            self.local_al_mac,
+                            forwarding_interface_mac,
+                        ),
+                    );
+                    sent_notification = true;
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_response");
+                }
             }
         }
+        sent_notification
     }
 
     /// Handles and logs TLVs from the CMDU payload for Topology Notification.
@@ -668,7 +677,7 @@ impl CMDUHandler {
             ..Default::default()
         };
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 received_device_data,
                 UpdateType::NotificationReceived,
@@ -684,31 +693,35 @@ impl CMDUHandler {
             "Topology Notification Processed",
         );
 
-        match transmission_event {
-            TransmissionEvent::SendTopologyQuery(dest_mac) => {
-                let forwarding_interface = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_topo_query/{remote_al_mac_address}"),
-                    cmdu_topology_query_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        self.local_al_mac,
-                        dest_mac,
-                        forwarding_interface,
-                    ),
-                );
-                true
-            }
-            TransmissionEvent::None => {
-                debug!("No transmission event triggered by Topology Notification");
-                false
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_notification");
-                false
+        if transmission_events.is_empty() {
+            debug!("No transmission event triggered by Topology Notification");
+            return false;
+        }
+
+        let mut sent_query = false;
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyQuery(dest_mac) => {
+                    let forwarding_interface = topology_db.get_forwarding_interface_mac().await;
+                    spawn_named(
+                        format!("proxy_topo_query/{remote_al_mac_address}"),
+                        cmdu_topology_query_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            self.local_al_mac,
+                            dest_mac,
+                            forwarding_interface,
+                        ),
+                    );
+                    sent_query = true;
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_notification");
+                }
             }
         }
+        sent_query
     }
 
     /// Handles and logs TLVs for Link Metric Query.
@@ -807,7 +820,7 @@ impl CMDUHandler {
         };
 
         let topo_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
-        let transmission_event = topo_db
+        let transmission_events = topo_db
             .update_ieee1905_topology(
                 device_data,
                 UpdateType::ApAutoConfigSearch,
@@ -817,33 +830,39 @@ impl CMDUHandler {
             )
             .await;
 
-        match transmission_event {
-            TransmissionEvent::StartLinkMetricQueryWorker((destination, cancellation_token)) => {
-                debug!(
-                    al_mac = %al_mac.al_mac_address,
-                    source = %source_mac,
-                    "Topology update started link metric query worker"
-                );
-                spawn_named(
-                    format!("proxy_link_metric_query/{destination}"),
-                    cmdu_link_metric_query_transmission_worker(
-                        topo_db,
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        local_interface_mac,
-                        destination,
-                        cancellation_token,
-                    ),
-                );
+        if transmission_events.is_empty() {
+            debug!(
+                al_mac = %al_mac.al_mac_address,
+                source = %source_mac,
+                "Topology update did not require sending notification"
+            );
+        }
+
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::StartLinkMetricQueryWorker((
+                    destination,
+                    cancellation_token,
+                )) => {
+                    debug!(
+                        al_mac = %al_mac.al_mac_address,
+                        source = %source_mac,
+                        "Topology update started link metric query worker"
+                    );
+                    spawn_named(
+                        format!("proxy_link_metric_query/{destination}"),
+                        cmdu_link_metric_query_transmission_worker(
+                            topo_db.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            local_interface_mac,
+                            destination,
+                            cancellation_token,
+                        ),
+                    );
+                }
+                _ => warn!("Unexpected TransmissionEvent in handle_ap_auto_config_search"),
             }
-            TransmissionEvent::None => {
-                debug!(
-                    al_mac = %al_mac.al_mac_address,
-                    source = %source_mac,
-                    "Topology update did not require sending notification"
-                );
-            }
-            _ => warn!("Unexpected TransmissionEvent in handle_ap_auto_config_search"),
         }
 
         info!(source = %source_mac, "ApAutoConfigSearch Processed");

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -298,13 +298,6 @@ impl CMDUHandler {
             "Topology Discovery Processed",
         );
 
-        if transmission_events.is_empty() {
-            debug!(
-                remote = %remote_al_mac,
-                "No transmission needed after topology discovery update"
-            );
-        }
-
         for transmission_event in transmission_events {
             match transmission_event {
                 TransmissionEvent::SendTopologyQuery(destination_al_mac) => {
@@ -417,14 +410,6 @@ impl CMDUHandler {
             source = %source_mac,
             "Topology Query Processed",
         );
-
-        if transmission_events.is_empty() {
-            debug!(
-                remote = %remote_al_mac,
-                "No transmission needed after topology query update"
-            );
-            return false;
-        }
 
         let mut sent_response = false;
         for transmission_event in transmission_events {
@@ -595,15 +580,6 @@ impl CMDUHandler {
             "Topology Response Processed",
         );
 
-        if transmission_events.is_empty() {
-            debug!(
-                al_mac = %remote_al_mac,
-                source = %source_mac,
-                "Topology update did not require sending notification"
-            );
-            return false;
-        }
-
         let mut sent_notification = false;
         for transmission_event in transmission_events {
             match transmission_event {
@@ -692,11 +668,6 @@ impl CMDUHandler {
             source = %source_mac,
             "Topology Notification Processed",
         );
-
-        if transmission_events.is_empty() {
-            debug!("No transmission event triggered by Topology Notification");
-            return false;
-        }
 
         let mut sent_query = false;
         for transmission_event in transmission_events {
@@ -829,14 +800,6 @@ impl CMDUHandler {
                 None,
             )
             .await;
-
-        if transmission_events.is_empty() {
-            debug!(
-                al_mac = %al_mac.al_mac_address,
-                source = %source_mac,
-                "Topology update did not require sending notification"
-            );
-        }
 
         for transmission_event in transmission_events {
             match transmission_event {
@@ -1018,13 +981,17 @@ impl CMDUHandler {
         }
 
         let topology_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
-        let Some(node) = topology_db.find_device_by_port(source_mac).await else {
-            warn!(%source_mac, "GenericPhyQuery source node not found");
-            return false;
+        let remote_al_mac = {
+            let Some(mut node) = topology_db.lock_node_by_port_mut(source_mac).await else {
+                warn!(%source_mac, "GenericPhyQuery source node not found");
+                return false;
+            };
+
+            node.device_data.destination_frame_mac = source_mac;
+            node.device_data.al_mac
         };
 
         let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-        let remote_al_mac = node.device_data.al_mac;
 
         spawn_named(
             format!("proxy_generic_phy_response/{remote_al_mac}"),

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -971,7 +971,7 @@ impl CMDUHandler {
         debug!(
             source = %source_mac,
             msg_id = message_id,
-            interface = self.interface_name,
+            interface = %self.interface_name,
             "Handling GenericPhyQuery CMDU",
         );
 
@@ -1019,7 +1019,7 @@ impl CMDUHandler {
         debug!(
             source = %source_mac,
             msg_id = message_id,
-            interface = self.interface_name,
+            interface = %self.interface_name,
             "Handling GenericPhyResponse CMDU",
         );
 

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -761,14 +761,6 @@ pub async fn cmdu_generic_phy_query_transmission_worker(
         debug!(%destination_mac, message_id, "Creating CMDU Generic PHY Query");
 
         if let Some(mut node) = topo_db.lock_node_by_port_mut(destination_mac).await {
-            if node
-                .metadata
-                .local_generic_phy_query_message_id
-                .is_some_and(|e| e.1.elapsed() <= Duration::from_secs(1))
-            {
-                debug!(%destination_mac, "Generic PHY Query already pending");
-                continue;
-            }
             node.metadata.local_generic_phy_query_message_id = Some((message_id, Instant::now()));
         }
 
@@ -826,7 +818,7 @@ pub async fn cmdu_generic_phy_response_transmission(
     // TODO: Add Generic PHY interface data
     let payload = [
         TLV::from(GenericPhyDeviceInformation {
-            al_mac: db.al_mac_address,
+            al_mac: local_al_mac_address,
             local_interfaces: Vec::new(),
         }),
         TLV::from(EndOfMessage),

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -823,8 +823,14 @@ pub async fn cmdu_generic_phy_response_transmission(
         return warn!(al_mac = %remote_al_mac_address, "Node not found");
     };
 
-    let generic_phy = build_local_generic_phy_device_information(&db).await;
-    let payload = [TLV::from(generic_phy), TLV::from(EndOfMessage)];
+    // TODO: Add Generic PHY interface data
+    let payload = [
+        TLV::from(GenericPhyDeviceInformation {
+            al_mac: db.al_mac_address,
+            local_interfaces: Vec::new(),
+        }),
+        TLV::from(EndOfMessage),
+    ];
 
     let cmdu = CMDU {
         message_version: MessageVersion::Version2013.to_u8(),
@@ -851,16 +857,6 @@ pub async fn cmdu_generic_phy_response_transmission(
             "CMDU Generic PHY Response sent successfully"
         ),
         Err(e) => error!(message_id, "Failed to send CMDU Generic PHY Response: {e}",),
-    }
-}
-
-async fn build_local_generic_phy_device_information(
-    db: &TopologyDatabase,
-) -> GenericPhyDeviceInformation {
-    // TODO: Add Generic PHY interface data
-    GenericPhyDeviceInformation {
-        al_mac: db.al_mac_address,
-        local_interfaces: Vec::new(),
     }
 }
 

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -738,6 +738,134 @@ pub async fn cmdu_link_metric_response_transmission(
 
 #[instrument(
     skip_all,
+    name = "cmdu_generic_phy_query_worker",
+    fields(task = next_task_id(), mac = %destination_mac),
+)]
+pub async fn cmdu_generic_phy_query_transmission_worker(
+    topo_db: Arc<TopologyDatabase>,
+    sender: Arc<EthernetSender>,
+    message_id_generator: Arc<MessageIdGenerator>,
+    interface_mac_address: MacAddr,
+    destination_mac: MacAddr,
+    cancellation_token: CancellationToken,
+) {
+    let mut ticker = interval(Duration::from_secs(30));
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => (),
+            _ = cancellation_token.cancelled() => return,
+        }
+
+        let message_id = message_id_generator.next_id();
+        debug!(%destination_mac, message_id, "Creating CMDU Generic PHY Query");
+
+        if let Some(mut node) = topo_db.lock_node_by_port_mut(destination_mac).await {
+            if node
+                .metadata
+                .local_generic_phy_query_message_id
+                .is_some_and(|e| e.1.elapsed() <= Duration::from_secs(1))
+            {
+                debug!(%destination_mac, "Generic PHY Query already pending");
+                continue;
+            }
+            node.metadata.local_generic_phy_query_message_id = Some((message_id, Instant::now()));
+        }
+
+        let cmdu = CMDU {
+            message_version: MessageVersion::Version2013.to_u8(),
+            reserved: 0,
+            message_type: CMDUType::GenericPhyQuery.to_u16(),
+            message_id,
+            fragment: 0,
+            flags: CMDU::FLAG_LAST_FRAGMENT,
+            payload: TLV::from(EndOfMessage).serialize(),
+        };
+
+        match sender
+            .enqueue_frame(
+                destination_mac,
+                interface_mac_address,
+                EthernetSender::ETHER_TYPE,
+                cmdu.serialize(),
+            )
+            .await
+        {
+            Ok(()) => {
+                info!(%destination_mac, message_id, "CMDU Generic PHY Query sent successfully")
+            }
+            Err(e) => error!(message_id, "Failed to send CMDU Generic PHY Query: {e}"),
+        }
+    }
+}
+
+#[instrument(
+    skip_all,
+    name = "cmdu_generic_phy_response_transmission",
+    fields(task = next_task_id(), al_mac = %remote_al_mac_address),
+)]
+pub async fn cmdu_generic_phy_response_transmission(
+    interface: String,
+    sender: Arc<EthernetSender>,
+    local_al_mac_address: MacAddr,
+    remote_al_mac_address: MacAddr,
+    interface_mac_address: MacAddr,
+    message_id: u16,
+) {
+    debug!(
+        interface = %interface,
+        message_id,
+        "Creating CMDU Generic PHY Response",
+    );
+
+    let db = TopologyDatabase::get_instance(local_al_mac_address, &interface);
+    let Some(node) = db.get_device(remote_al_mac_address).await else {
+        return warn!(al_mac = %remote_al_mac_address, "Node not found");
+    };
+
+    let generic_phy = build_local_generic_phy_device_information(&db).await;
+    let payload = [TLV::from(generic_phy), TLV::from(EndOfMessage)];
+
+    let cmdu = CMDU {
+        message_version: MessageVersion::Version2013.to_u8(),
+        reserved: 0,
+        message_type: CMDUType::GenericPhyResponse.to_u16(),
+        message_id,
+        fragment: 0,
+        flags: CMDU::FLAG_LAST_FRAGMENT,
+        payload: payload.iter().flat_map(TLV::serialize).collect(),
+    };
+
+    match enqueue_fragmented_cmdu(
+        &sender,
+        node.device_data.destination_frame_mac,
+        interface_mac_address,
+        cmdu,
+        node.device_data.supported_fragmentation,
+    )
+    .await
+    {
+        Ok(()) => info!(
+            interface = %interface,
+            message_id,
+            "CMDU Generic PHY Response sent successfully"
+        ),
+        Err(e) => error!(message_id, "Failed to send CMDU Generic PHY Response: {e}",),
+    }
+}
+
+async fn build_local_generic_phy_device_information(
+    db: &TopologyDatabase,
+) -> GenericPhyDeviceInformation {
+    // TODO: Add Generic PHY interface data
+    GenericPhyDeviceInformation {
+        al_mac: db.al_mac_address,
+        local_interfaces: Vec::new(),
+    }
+}
+
+#[instrument(
+    skip_all,
     name = "cmdu_higher_layer_query_worker",
     fields(task = next_task_id(), mac = %destination_mac),
 )]

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -24,7 +24,8 @@ use crate::artifact_exchange_service::client::{
     ArtifactExchangeClient, ArtifactExchangeClientFactory,
 };
 use crate::cmdu_codec::{
-    ControlUrl, Ipv4, Ipv6, LinkMetricRx, LinkMetricRxPair, LinkMetricTx, LinkMetricTxPair,
+    ControlUrl, GenericPhyDeviceInformation, Ipv4, Ipv6, LinkMetricRx, LinkMetricRxPair,
+    LinkMetricTx, LinkMetricTxPair,
 };
 use crate::interface_manager::get_interfaces;
 use crate::linux::if_link::RtnlLinkStats64;
@@ -102,6 +103,7 @@ pub enum TransmissionEvent {
     SendTopologyNotification(MacAddr),
     StartLinkMetricQueryWorker((MacAddr, CancellationToken)),
     StartHigherLayerQueryWorker((MacAddr, CancellationToken)),
+    StartGenericPhyQueryWorker((MacAddr, CancellationToken)),
     None,
 }
 
@@ -266,6 +268,7 @@ pub struct Ieee1905NodeInfo {
     pub local_message_id: Option<u16>,
     pub local_link_metric_query_message_id: Option<(u16, Instant)>,
     pub local_hle_query_message_id: Option<(u16, Instant)>,
+    pub local_generic_phy_query_message_id: Option<(u16, Instant)>,
     /// last msg id received from this node
     /// this excludes response ids, those are always copied from the query
     pub remote_message_id: Option<u16>,
@@ -290,6 +293,7 @@ impl Ieee1905NodeInfo {
             local_message_id: None,
             local_link_metric_query_message_id: None,
             local_hle_query_message_id: None,
+            local_generic_phy_query_message_id: None,
             remote_message_id: None,
             lldp_neighbor,
             node_state_local,
@@ -368,6 +372,7 @@ pub struct Ieee1905DeviceData {
     pub link_metric_rx: Vec<LinkMetricRx>,
     pub link_metric_tx: Vec<LinkMetricTx>,
     pub l2_neighbor_devices: Vec<L2NeighborDevice>,
+    pub generic_phy_device_information: Option<GenericPhyDeviceInformation>,
 }
 
 impl Ieee1905DeviceData {
@@ -445,6 +450,7 @@ pub struct Ieee1905NodeInternal {
     artifact_exchange_client: Option<(String, ArtifactExchangeClient)>,
     link_metrics_query_cancellation_token: Option<tokio_util::sync::DropGuard>,
     higher_layer_query_cancellation_token: Option<tokio_util::sync::DropGuard>,
+    generic_phy_query_cancellation_token: Option<tokio_util::sync::DropGuard>,
 }
 
 impl Ieee1905NodeInternal {
@@ -456,6 +462,7 @@ impl Ieee1905NodeInternal {
             artifact_exchange_client: None,
             link_metrics_query_cancellation_token: None,
             higher_layer_query_cancellation_token: None,
+            generic_phy_query_cancellation_token: None,
         }
     }
 
@@ -498,6 +505,21 @@ impl Ieee1905NodeInternal {
         self.higher_layer_query_cancellation_token = Some(drop_guard);
 
         TransmissionEvent::StartHigherLayerQueryWorker((
+            self.device_data.destination_frame_mac,
+            cancellation_token,
+        ))
+    }
+
+    fn prepare_generic_phy_query_transmission_event_if_needed(&mut self) -> TransmissionEvent {
+        if self.generic_phy_query_cancellation_token.is_some() {
+            return TransmissionEvent::None;
+        }
+
+        let cancellation_token = CancellationToken::new();
+        let drop_guard = cancellation_token.clone().drop_guard();
+        self.generic_phy_query_cancellation_token = Some(drop_guard);
+
+        TransmissionEvent::StartGenericPhyQueryWorker((
             self.device_data.destination_frame_mac,
             cancellation_token,
         ))
@@ -927,8 +949,8 @@ impl TopologyDatabase {
                                     debug!("Event: Send Topology Notification");
                                     TransmissionEvent::SendTopologyNotification(multicast_mac)
                                 } else {
-                                    debug!("Device data unchanged — no transmission needed");
-                                    TransmissionEvent::None
+                                    debug!("Device data unchanged");
+                                    node.prepare_generic_phy_query_transmission_event_if_needed()
                                 }
                             } else {
                                 debug!("Ignoring ResponseReceived — not in ConvergingLocal state");
@@ -994,6 +1016,7 @@ impl TopologyDatabase {
                             local_message_id: local_msg_id,
                             local_link_metric_query_message_id: None,
                             local_hle_query_message_id: None,
+                            local_generic_phy_query_message_id: None,
                             remote_message_id: remote_msg_id,
                             lldp_neighbor,
                             node_state_local: StateLocal::Idle,
@@ -1002,6 +1025,7 @@ impl TopologyDatabase {
                         device_data,
                         link_metrics_query_cancellation_token: None,
                         higher_layer_query_cancellation_token: None,
+                        generic_phy_query_cancellation_token: None,
                         artifact_exchange_client: None,
                     };
 
@@ -1116,6 +1140,53 @@ impl TopologyDatabase {
 
         trace!(%source, "link metric rx stats: {:#?}", node.device_data.link_metric_rx);
         trace!(%source, "link metric tx stats: {:#?}", node.device_data.link_metric_tx);
+    }
+
+    pub async fn handle_generic_phy_response(
+        &self,
+        source: MacAddr,
+        message_id: u16,
+        generic_phy: GenericPhyDeviceInformation,
+    ) -> bool {
+        let mut nodes = self.nodes.write().await;
+        let Some(node) = Self::find_node_by_port_mut(nodes.values_mut(), source) else {
+            debug!(%source, "generic_phy_response — node not found");
+            return false;
+        };
+
+        if node.device_data.al_mac != generic_phy.al_mac {
+            warn!(
+                source = %source,
+                expected = %node.device_data.al_mac,
+                got = %generic_phy.al_mac,
+                "generic_phy_response — AL MAC mismatch",
+            );
+            return false;
+        }
+
+        let local_query_message_id = node
+            .metadata
+            .local_generic_phy_query_message_id
+            .take_if(|e| e.0 == message_id && e.1.elapsed() <= Duration::from_secs(1));
+
+        if local_query_message_id.is_none() {
+            warn!(
+                %source,
+                got = message_id,
+                exp = ?node.metadata.local_generic_phy_query_message_id,
+                "generic_phy_response — unexpected message id",
+            );
+            return false;
+        }
+
+        if node.device_data.generic_phy_device_information.as_ref() == Some(&generic_phy) {
+            debug!(%source, "generic_phy_response — data unchanged");
+            return false;
+        }
+
+        node.device_data.generic_phy_device_information = Some(generic_phy);
+        info!(%source, "generic_phy_response — topology Generic PHY data updated");
+        true
     }
 
     pub async fn handle_ap_auto_config_response(

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -104,7 +104,6 @@ pub enum TransmissionEvent {
     StartLinkMetricQueryWorker((MacAddr, CancellationToken)),
     StartHigherLayerQueryWorker((MacAddr, CancellationToken)),
     StartGenericPhyQueryWorker((MacAddr, CancellationToken)),
-    None,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -480,49 +479,55 @@ impl Ieee1905NodeInternal {
         }
     }
 
-    fn prepare_link_metrics_query_transmission_event_if_needed(&mut self) -> TransmissionEvent {
+    fn prepare_link_metrics_query_transmission_event_if_needed(
+        &mut self,
+    ) -> Option<TransmissionEvent> {
         if self.link_metrics_query_cancellation_token.is_some() {
-            return TransmissionEvent::None;
+            return None;
         }
 
         let cancellation_token = CancellationToken::new();
         let drop_guard = cancellation_token.clone().drop_guard();
         self.link_metrics_query_cancellation_token = Some(drop_guard);
 
-        TransmissionEvent::StartLinkMetricQueryWorker((
+        Some(TransmissionEvent::StartLinkMetricQueryWorker((
             self.device_data.destination_frame_mac,
             cancellation_token,
-        ))
+        )))
     }
 
-    fn prepare_higher_layer_query_transmission_event_if_needed(&mut self) -> TransmissionEvent {
+    fn prepare_higher_layer_query_transmission_event_if_needed(
+        &mut self,
+    ) -> Option<TransmissionEvent> {
         if self.higher_layer_query_cancellation_token.is_some() {
-            return TransmissionEvent::None;
+            return None;
         }
 
         let cancellation_token = CancellationToken::new();
         let drop_guard = cancellation_token.clone().drop_guard();
         self.higher_layer_query_cancellation_token = Some(drop_guard);
 
-        TransmissionEvent::StartHigherLayerQueryWorker((
+        Some(TransmissionEvent::StartHigherLayerQueryWorker((
             self.device_data.destination_frame_mac,
             cancellation_token,
-        ))
+        )))
     }
 
-    fn prepare_generic_phy_query_transmission_event_if_needed(&mut self) -> TransmissionEvent {
+    fn prepare_generic_phy_query_transmission_event_if_needed(
+        &mut self,
+    ) -> Option<TransmissionEvent> {
         if self.generic_phy_query_cancellation_token.is_some() {
-            return TransmissionEvent::None;
+            return None;
         }
 
         let cancellation_token = CancellationToken::new();
         let drop_guard = cancellation_token.clone().drop_guard();
         self.generic_phy_query_cancellation_token = Some(drop_guard);
 
-        TransmissionEvent::StartGenericPhyQueryWorker((
+        Some(TransmissionEvent::StartGenericPhyQueryWorker((
             self.device_data.destination_frame_mac,
             cancellation_token,
-        ))
+        )))
     }
 
     fn update_artifact_exchange_client(
@@ -844,9 +849,9 @@ impl TopologyDatabase {
         local_msg_id: Option<u16>,
         remote_msg_id: Option<u16>,
         lldp_neighbor: Option<PortId>,
-    ) -> TransmissionEvent {
+    ) -> Vec<TransmissionEvent> {
         let al_mac = device_data.al_mac;
-        let transmission_event;
+        let transmission_events;
 
         //TODO: use new update types.
         tracing::debug!("WAITING for write lock");
@@ -860,7 +865,7 @@ impl TopologyDatabase {
 
                     node.device_data.local_interface_mac = device_data.local_interface_mac;
 
-                    transmission_event = match operation {
+                    transmission_events = match operation {
                         UpdateType::DiscoveryReceived => {
                             let local_state = node.metadata.node_state_local;
 
@@ -875,9 +880,16 @@ impl TopologyDatabase {
                             );
 
                             if local_state == StateLocal::Idle {
-                                TransmissionEvent::SendTopologyQuery(al_mac)
+                                vec![TransmissionEvent::SendTopologyQuery(al_mac)]
                             } else {
-                                node.prepare_higher_layer_query_transmission_event_if_needed()
+                                let mut events = Vec::new();
+                                events.extend(
+                                    node.prepare_higher_layer_query_transmission_event_if_needed(),
+                                );
+                                events.extend(
+                                    node.prepare_generic_phy_query_transmission_event_if_needed(),
+                                );
+                                events
                             }
                         }
                         UpdateType::NotificationReceived => {
@@ -892,9 +904,9 @@ impl TopologyDatabase {
                                     Some(StateLocal::Idle),
                                     None,
                                 );
-                                TransmissionEvent::SendTopologyQuery(al_mac)
+                                vec![TransmissionEvent::SendTopologyQuery(al_mac)]
                             } else {
-                                TransmissionEvent::None
+                                vec![]
                             }
                         }
                         UpdateType::QueryReceived { force } => {
@@ -910,9 +922,9 @@ impl TopologyDatabase {
                                     Some(StateRemote::ConvergingRemote(Instant::now())),
                                 );
                                 debug!("Event: Send Topology Response");
-                                TransmissionEvent::SendTopologyResponse(al_mac)
+                                vec![TransmissionEvent::SendTopologyResponse(al_mac)]
                             } else {
-                                TransmissionEvent::None
+                                vec![]
                             }
                         }
 
@@ -947,14 +959,14 @@ impl TopologyDatabase {
                                     let multicast_mac =
                                         MacAddr::new(0x01, 0x80, 0xC2, 0x00, 0x00, 0x13);
                                     debug!("Event: Send Topology Notification");
-                                    TransmissionEvent::SendTopologyNotification(multicast_mac)
+                                    vec![TransmissionEvent::SendTopologyNotification(multicast_mac)]
                                 } else {
                                     debug!("Device data unchanged");
-                                    node.prepare_generic_phy_query_transmission_event_if_needed()
+                                    vec![]
                                 }
                             } else {
                                 debug!("Ignoring ResponseReceived — not in ConvergingLocal state");
-                                TransmissionEvent::None
+                                vec![]
                             }
                         }
 
@@ -969,7 +981,7 @@ impl TopologyDatabase {
                                     None,
                                 );
                             }
-                            TransmissionEvent::None
+                            vec![]
                         }
                         UpdateType::ResponseSent => {
                             if let StateRemote::ConvergingRemote(_) =
@@ -984,7 +996,7 @@ impl TopologyDatabase {
                                     Some(StateRemote::ConvergedRemote),
                                 );
                             }
-                            TransmissionEvent::None
+                            vec![]
                         }
                         UpdateType::LldpUpdate => {
                             node.metadata.update(
@@ -996,13 +1008,14 @@ impl TopologyDatabase {
                                 None,
                             );
                             debug!(al_mac = ?al_mac, lldp_neighbor = ?lldp_neighbor, "Updated LLDP neighbor status");
-                            TransmissionEvent::None
+                            vec![]
                             //If needed we can indicate here a notification event to update topology data base in al neighbors but for now it is not needed
                             //initial DB snapshot covers current uses cases for RDK-B but we can update this part if needed in the future
                         }
-                        UpdateType::ApAutoConfigSearch => {
-                            node.prepare_link_metrics_query_transmission_event_if_needed()
-                        }
+                        UpdateType::ApAutoConfigSearch => node
+                            .prepare_link_metrics_query_transmission_event_if_needed()
+                            .into_iter()
+                            .collect(),
                     };
                 }
                 None => {
@@ -1030,12 +1043,12 @@ impl TopologyDatabase {
                     };
 
                     let node_was_created;
-                    transmission_event = match operation {
+                    transmission_events = match operation {
                         UpdateType::DiscoveryReceived => {
                             nodes.insert(al_mac, new_node);
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from Discovery");
-                            TransmissionEvent::SendTopologyQuery(al_mac)
+                            vec![TransmissionEvent::SendTopologyQuery(al_mac)]
                         }
                         UpdateType::QueryReceived { .. } => {
                             new_node.metadata.node_state_remote =
@@ -1043,18 +1056,20 @@ impl TopologyDatabase {
                             nodes.insert(al_mac, new_node);
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from query");
-                            TransmissionEvent::SendTopologyResponse(al_mac)
+                            vec![TransmissionEvent::SendTopologyResponse(al_mac)]
                         }
                         UpdateType::ApAutoConfigSearch => {
                             let node = nodes.entry(al_mac).insert_entry(new_node).into_mut();
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from ApAutoConfigSearch");
                             node.prepare_link_metrics_query_transmission_event_if_needed()
+                                .into_iter()
+                                .collect()
                         }
                         _ => {
                             debug!(al_mac = ?al_mac, operation = ?operation, "Insertion skipped — unsupported operation");
                             node_was_created = false;
-                            TransmissionEvent::None
+                            vec![]
                         }
                     };
 
@@ -1069,7 +1084,7 @@ impl TopologyDatabase {
         }
 
         debug!("Lock released — function continues safely");
-        transmission_event
+        transmission_events
     }
 
     pub async fn handle_notification_sent(&self) {


### PR DESCRIPTION
Added IEEE 1905.1 Generic PHY Query / Response support.

- Generic PHY Query and Response CMDU types
- Generic PHY Device Information TLV parsing/serialization
- Generic PHY Response handling and forwarding to topology manager
- Changed topology update handling to return a vector of transmission events.

Note: Local Generic PHY interface details are not populated yet.


<img width="1224" height="470" alt="image" src="https://github.com/user-attachments/assets/89394984-71b5-4dc8-bc95-10f383501391" />

[ieee1905_generic_phy.zip](https://github.com/user-attachments/files/29884148/ieee1905_generic_phy.zip)


