### PR TITLE
[#423] Added logic behind ApOperationalBss and BssConfigurationReport TLVs

### DIFF
--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -19,14 +19,14 @@
 
 #![deny(warnings)]
 
-// External crates
-use nom::{Err as NomErr, Needed};
 use nom::{
     IResult, Parser,
     bytes::complete::take,
     error::{Error, ErrorKind},
     number::complete::{be_i8, be_u8, be_u16, be_u32},
 };
+// External crates
+use nom::{Err as NomErr, Needed};
 
 // Internal modules
 use crate::cmdu_reassembler::CmduReassemblyError;
@@ -174,9 +174,11 @@ pub enum IEEE1905TLVType {
     Ieee1905ProfileVersion,
     L2NeighborDevice,
     SupportedService,
+    ApOperationalBss,
     ClientAssociation,
     MultiApProfile,
     Profile2ApCapability,
+    BssConfigurationReport,
     DeviceInventory,
     Unknown(u8), // To handle unknown or unsupported TLV types
 }
@@ -208,9 +210,11 @@ impl IEEE1905TLVType {
             0x1a => IEEE1905TLVType::Ieee1905ProfileVersion,
             0x1e => IEEE1905TLVType::L2NeighborDevice,
             0x80 => IEEE1905TLVType::SupportedService,
+            0x83 => IEEE1905TLVType::ApOperationalBss,
             0x92 => IEEE1905TLVType::ClientAssociation,
             0xb3 => IEEE1905TLVType::MultiApProfile,
             0xb4 => IEEE1905TLVType::Profile2ApCapability,
+            0xb7 => IEEE1905TLVType::BssConfigurationReport,
             0xd4 => IEEE1905TLVType::DeviceInventory,
             _ => IEEE1905TLVType::Unknown(value), // For unrecognized types
         }
@@ -242,9 +246,11 @@ impl IEEE1905TLVType {
             IEEE1905TLVType::Ieee1905ProfileVersion => 0x1a,
             IEEE1905TLVType::L2NeighborDevice => 0x1e,
             IEEE1905TLVType::SupportedService => 0x80,
+            IEEE1905TLVType::ApOperationalBss => 0x83,
             IEEE1905TLVType::ClientAssociation => 0x92,
             IEEE1905TLVType::MultiApProfile => 0xb3,
             IEEE1905TLVType::Profile2ApCapability => 0xb4,
+            IEEE1905TLVType::BssConfigurationReport => 0xb7,
             IEEE1905TLVType::DeviceInventory => 0xd4,
             IEEE1905TLVType::Unknown(value) => value, // Return the unknown value as-is
         }
@@ -1349,6 +1355,88 @@ impl TLVTrait for SupportedService {
 }
 
 ///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApOperationalBss {
+    pub radios: Vec<ApOperationalBssRadio>,
+}
+
+impl TLVTrait for ApOperationalBss {
+    const TYPE: IEEE1905TLVType = IEEE1905TLVType::ApOperationalBss;
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, radios) = length_count(u8, ApOperationalBssRadio::parse).parse(input)?;
+
+        Ok((input, Self { radios }))
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        vec.extend((self.radios.len() as u8).to_be_bytes());
+        vec.extend(self.radios.iter().flat_map(|e| e.serialize()));
+        vec
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApOperationalBssRadio {
+    pub radio_unique_id: MacAddr,
+    pub bss: Vec<ApOperationalBssInterface>,
+}
+
+impl ApOperationalBssRadio {
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, radio_unique_id) = take_mac_addr(input)?;
+        let (input, bss) = length_count(u8, ApOperationalBssInterface::parse).parse(input)?;
+
+        let this = Self {
+            radio_unique_id,
+            bss,
+        };
+
+        Ok((input, this))
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        vec.extend(self.radio_unique_id.octets());
+        vec.extend((self.bss.len() as u8).to_be_bytes());
+        vec.extend(self.bss.iter().flat_map(|e| e.serialize()));
+        vec
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApOperationalBssInterface {
+    pub ap_mac: MacAddr,
+    pub ssid: Vec<u8>,
+}
+
+impl ApOperationalBssInterface {
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, ap_mac) = take_mac_addr(input)?;
+        let (input, ssid) = length_count(u8, u8).parse(input)?;
+
+        Ok((input, Self { ap_mac, ssid }))
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        vec.extend(self.ap_mac.octets());
+        vec.extend((self.ssid.len() as u8).to_be_bytes());
+        vec.extend(self.ssid.as_slice());
+        vec
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssociationState {
     LeftBss,
@@ -1534,6 +1622,108 @@ impl ByteCounterUnits {
             ByteCounterUnits::MiB => 2,
             ByteCounterUnits::Reserved => 3,
         }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BssConfigurationReport {
+    pub radios: Vec<BssConfigurationReportRadio>,
+}
+
+impl TLVTrait for BssConfigurationReport {
+    const TYPE: IEEE1905TLVType = IEEE1905TLVType::BssConfigurationReport;
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, radios) = length_count(u8, BssConfigurationReportRadio::parse).parse(input)?;
+
+        Ok((input, Self { radios }))
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        vec.extend((self.radios.len() as u8).to_be_bytes());
+        vec.extend(self.radios.iter().flat_map(|e| e.serialize()));
+        vec
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BssConfigurationReportRadio {
+    pub radio_unique_id: MacAddr,
+    pub bss: Vec<BssConfigurationReportInterface>,
+}
+
+impl BssConfigurationReportRadio {
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, radio_unique_id) = take_mac_addr(input)?;
+        let (input, bss) = length_count(u8, BssConfigurationReportInterface::parse).parse(input)?;
+
+        let this = Self {
+            radio_unique_id,
+            bss,
+        };
+
+        Ok((input, this))
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        vec.extend(self.radio_unique_id.octets());
+        vec.extend((self.bss.len() as u8).to_be_bytes());
+        vec.extend(self.bss.iter().flat_map(|e| e.serialize()));
+        vec
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BssConfigurationReportInterface {
+    pub bssid: MacAddr,
+    pub flags: u8,
+    pub flags_reserved: u8,
+    pub ssid: Vec<u8>,
+}
+
+impl BssConfigurationReportInterface {
+    pub const FLAG_BACK_HAUL_BSS: u8 = 1 << 7;
+    pub const FLAG_FRONT_HAUL_BSS: u8 = 1 << 6;
+    pub const FLAG_R1_DISALLOWED_STATUS: u8 = 1 << 5;
+    pub const FLAG_R2_DISALLOWED_STATUS: u8 = 1 << 4;
+    pub const FLAG_MULTIPLE_BSSID: u8 = 1 << 3;
+    pub const FLAG_TRANSMITTED_BSSID: u8 = 1 << 2;
+
+    fn parse(input: &[u8]) -> IResult<&[u8], Self> {
+        use nom::number::complete::u8;
+
+        let (input, bssid) = take_mac_addr(input)?;
+        let (input, flags) = be_u8(input)?;
+        let (input, flags_reserved) = be_u8(input)?;
+        let (input, ssid) = length_count(u8, u8).parse(input)?;
+
+        let this = Self {
+            bssid,
+            flags,
+            flags_reserved,
+            ssid,
+        };
+
+        Ok((input, this))
+    }
+
+    fn serialize(&self) -> Vec<u8> {
+        let mut vec = Vec::new();
+        vec.extend(self.bssid.octets());
+        vec.extend(self.flags.to_be_bytes());
+        vec.extend(self.flags_reserved.to_be_bytes());
+        vec.extend((self.ssid.len() as u8).to_be_bytes());
+        vec.extend(self.ssid.as_slice());
+        vec
     }
 }
 
@@ -2628,6 +2818,10 @@ pub mod tests {
             IEEE1905TLVType::SupportedService,
         );
         assert_eq!(
+            IEEE1905TLVType::from_u8(0x83),
+            IEEE1905TLVType::ApOperationalBss,
+        );
+        assert_eq!(
             IEEE1905TLVType::from_u8(0x92),
             IEEE1905TLVType::ClientAssociation,
         );
@@ -2638,6 +2832,10 @@ pub mod tests {
         assert_eq!(
             IEEE1905TLVType::from_u8(0xb4),
             IEEE1905TLVType::Profile2ApCapability,
+        );
+        assert_eq!(
+            IEEE1905TLVType::from_u8(0xb7),
+            IEEE1905TLVType::BssConfigurationReport,
         );
         assert_eq!(
             IEEE1905TLVType::from_u8(0xd4),
@@ -2678,11 +2876,16 @@ pub mod tests {
         assert_eq!(SearchedRole::TYPE, IEEE1905TLVType::SearchedRole);
         assert_eq!(SupportedRole::TYPE, IEEE1905TLVType::SupportedRole);
         assert_eq!(SupportedService::TYPE, IEEE1905TLVType::SupportedService);
+        assert_eq!(ApOperationalBss::TYPE, IEEE1905TLVType::ApOperationalBss);
         assert_eq!(ClientAssociation::TYPE, IEEE1905TLVType::ClientAssociation);
         assert_eq!(MultiApProfile::TYPE, IEEE1905TLVType::MultiApProfile);
         assert_eq!(
             Profile2ApCapability::TYPE,
             IEEE1905TLVType::Profile2ApCapability,
+        );
+        assert_eq!(
+            BssConfigurationReport::TYPE,
+            IEEE1905TLVType::BssConfigurationReport,
         );
         assert_eq!(DeviceInventory::TYPE, IEEE1905TLVType::DeviceInventory);
     }
@@ -2714,9 +2917,11 @@ pub mod tests {
         assert_eq!(IEEE1905TLVType::DeviceIdentificationType.to_u8(), 0x15);
         assert_eq!(IEEE1905TLVType::Ieee1905ProfileVersion.to_u8(), 0x1a);
         assert_eq!(IEEE1905TLVType::SupportedService.to_u8(), 0x80);
+        assert_eq!(IEEE1905TLVType::ApOperationalBss.to_u8(), 0x83);
         assert_eq!(IEEE1905TLVType::ClientAssociation.to_u8(), 0x92);
         assert_eq!(IEEE1905TLVType::MultiApProfile.to_u8(), 0xb3);
         assert_eq!(IEEE1905TLVType::Profile2ApCapability.to_u8(), 0xb4);
+        assert_eq!(IEEE1905TLVType::BssConfigurationReport.to_u8(), 0xb7);
         assert_eq!(IEEE1905TLVType::DeviceInventory.to_u8(), 0xd4);
     }
 
@@ -4007,6 +4212,23 @@ pub mod tests {
     }
 
     #[test]
+    fn test_ap_operational_bss_parse_and_serialize() {
+        let original = ApOperationalBss {
+            radios: vec![ApOperationalBssRadio {
+                radio_unique_id: MacAddr::new(0x00, 0x01, 0x02, 0x03, 0x04, 0x05),
+                bss: vec![ApOperationalBssInterface {
+                    ap_mac: MacAddr::new(0x01, 0x02, 0x03, 0x04, 0x05, 0x06),
+                    ssid: b"NestWifiEver".to_vec(),
+                }],
+            }],
+        };
+
+        let serialized = original.serialize();
+        let parsed = ApOperationalBss::parse(&serialized).unwrap().1;
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
     fn test_client_association_serialization() {
         let original = ClientAssociation {
             sta_mac: MacAddr::new(1, 2, 3, 4, 5, 6),
@@ -4068,6 +4290,25 @@ pub mod tests {
         assert_eq!(ByteCounterUnits::KiB.to_u8(), 0x01);
         assert_eq!(ByteCounterUnits::MiB.to_u8(), 0x02);
         assert_eq!(ByteCounterUnits::Reserved.to_u8(), 0x03);
+    }
+
+    #[test]
+    fn test_bss_configuration_report_serialization() {
+        let original = BssConfigurationReport {
+            radios: vec![BssConfigurationReportRadio {
+                radio_unique_id: MacAddr::new(0x00, 0x01, 0x02, 0x03, 0x04, 0x05),
+                bss: vec![BssConfigurationReportInterface {
+                    bssid: MacAddr::new(0x01, 0x01, 0x02, 0x03, 0x04, 0x05),
+                    flags: BssConfigurationReportInterface::FLAG_BACK_HAUL_BSS,
+                    flags_reserved: 0,
+                    ssid: b"BestWifiEver".to_vec(),
+                }],
+            }],
+        };
+
+        let serialized = original.serialize();
+        let parsed = BssConfigurationReport::parse(&serialized).unwrap().1;
+        assert_eq!(parsed, original);
     }
 
     #[test]

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -16,19 +16,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-use crate::SDU;
 use crate::al_sap::AlServiceAccessPoint;
 use crate::cmdu::TLV;
 use crate::cmdu_codec::*;
 use crate::ethernet_subject_transmission::EthernetSender;
 use crate::interface_manager::get_mac_address_by_interface;
+use crate::registration_codec::ServiceType;
 use crate::tlv_cmdu_codec::TLVTrait;
 use crate::topology_manager::{Ieee1905Node, Role, TopologyDatabase, UpdateType};
-use crate::{MessageIdGenerator, next_task_id};
+use crate::SDU;
+use crate::{next_task_id, MessageIdGenerator};
 use pnet::datalink::MacAddr;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::time::{Duration, Instant, interval};
+use tokio::time::{interval, Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, instrument, trace, warn};
 
@@ -321,7 +322,9 @@ async fn inject_topology_response_tlvs(
         Ieee1905NeighborDevice::TYPE.to_u8(),
         NonIeee1905NeighborDevices::TYPE.to_u8(),
         L2NeighborDevice::TYPE.to_u8(),
-        Ipv6::TYPE.to_u8(),
+        SupportedService::TYPE.to_u8(),
+        ApOperationalBss::TYPE.to_u8(),
+        BssConfigurationReport::TYPE.to_u8(),
     ];
     vec.retain(|e| !filtered_types.contains(&e.tlv_type));
 
@@ -454,6 +457,61 @@ async fn inject_topology_response_tlvs(
             }));
         }
     }
+
+    // injecting SupportedService
+    if let Some(al_sap) = AlServiceAccessPoint::get().await
+        && let Some(service_type) = al_sap.service_type()
+    {
+        vec.push(TLV::from(SupportedService {
+            services: vec![match service_type {
+                ServiceType::EasyMeshAgent => SupportedServiceType::Agent,
+                ServiceType::EasyMeshController => SupportedServiceType::Controller,
+            }],
+        }));
+    }
+
+    // injecting ApOperationalBss
+    vec.push({
+        let radios = db.ap_operational_bss.read().await;
+        let radios = radios.iter().map(|radio| ApOperationalBssRadio {
+            radio_unique_id: radio.radio_unique_id,
+            bss: radio
+                .bss_list
+                .iter()
+                .map(|bss| ApOperationalBssInterface {
+                    ap_mac: bss.bssid,
+                    ssid: bss.ssid.clone(),
+                })
+                .collect(),
+        });
+
+        TLV::from(ApOperationalBss {
+            radios: radios.collect(),
+        })
+    });
+
+    // injecting BssConfigurationReport
+    vec.push({
+        let radios = db.ap_operational_bss.read().await;
+        let radios = radios.iter().map(|radio| BssConfigurationReportRadio {
+            radio_unique_id: radio.radio_unique_id,
+            bss: radio
+                .bss_list
+                .iter()
+                .map(|bss| BssConfigurationReportInterface {
+                    bssid: bss.bssid,
+                    flags: BssConfigurationReportInterface::FLAG_BACK_HAUL_BSS
+                        | BssConfigurationReportInterface::FLAG_FRONT_HAUL_BSS,
+                    flags_reserved: 0,
+                    ssid: bss.ssid.clone(),
+                })
+                .collect(),
+        });
+
+        TLV::from(BssConfigurationReport {
+            radios: radios.collect(),
+        })
+    });
 
     // injecting VendorInfo
     if db.get_artifact_exchange_server_ip_address().is_some() {
@@ -1014,7 +1072,7 @@ mod tests {
         let db = TopologyDatabase::new(MacAddr::broadcast(), "if_name".to_string());
         let response = inject_topology_response_tlvs(&mut vec, &db).await;
         assert!(response.is_ok());
-        assert_eq!(vec.len(), 3);
+        assert_eq!(vec.len(), 5);
     }
 
     #[tokio::test]

--- a/ieee1905-core/src/interface_manager.rs
+++ b/ieee1905-core/src/interface_manager.rs
@@ -20,21 +20,21 @@
 #![deny(warnings)]
 
 use netdev::interface::types::InterfaceType;
-use std::net::Ipv6Addr;
 // External crates
 use pnet::datalink::{self, MacAddr};
+use std::net::Ipv6Addr;
 
 // Standard library
 use crate::cmdu_codec::{MediaType, MediaTypeSpecialInfo, MediaTypeSpecialInfoWifi};
 use crate::linux::eth_tool::{
-    ETH_TOOL_GENL_NAME, EthToolBitsetAttr, EthToolBitsetBitAttr, EthToolHeaderAttribute,
-    EthToolLinkMode, EthToolLinkModesAttribute, EthToolMessage,
+    EthToolBitsetAttr, EthToolBitsetBitAttr, EthToolHeaderAttribute, EthToolLinkMode,
+    EthToolLinkModesAttribute, EthToolMessage, ETH_TOOL_GENL_NAME,
 };
 use crate::linux::if_link::{RtnlLinkStats, RtnlLinkStats64};
 use crate::linux::nl80211::{
-    NL80211_GENL_NAME, Nl80211Attribute, Nl80211Band, Nl80211BandAttr, Nl80211BandIfTypeAttr,
-    Nl80211BitrateAttr, Nl80211ChannelWidth, Nl80211Command, Nl80211IfType, Nl80211RateInfo,
-    Nl80211StaInfo, Nl80211SurveyInfoAttr,
+    Nl80211Attribute, Nl80211Band, Nl80211BandAttr, Nl80211BandIfTypeAttr, Nl80211BitrateAttr,
+    Nl80211ChannelWidth, Nl80211Command, Nl80211IfType, Nl80211RateInfo, Nl80211StaInfo,
+    Nl80211SurveyInfoAttr, NL80211_GENL_NAME,
 };
 use crate::topology_manager::{Ieee1905InterfaceData, Ieee1905LocalInterface};
 use indexmap::{IndexMap, IndexSet};
@@ -129,7 +129,7 @@ pub async fn get_interfaces(
     filter_interfaces_by_bridge(forwarding_if_name, &mut links).await;
 
     // filter out veth (virtual) interfaces
-    links.retain(|_, e| e.link_kind.as_deref() != Some("veth"));
+    links.retain(|_, e| e.if_name == forwarding_if_name || e.link_kind.as_deref() != Some("veth"));
 
     match get_wireless_interfaces(&mut links).await {
         Ok(e) => interfaces.extend(e),
@@ -180,20 +180,22 @@ async fn filter_interfaces_by_bridge(
 }
 
 async fn filter_interfaces_by_ovs_bridge(
-    mut forwarding_if_name: &str,
+    forwarding_if_name: &str,
     links: &mut IndexMap<i32, LinkInterfaceInfo>,
 ) -> bool {
+    let mut bridge_child_if_name = forwarding_if_name;
+
     // select other veth pair endpoint if current endpoint is not connected to the bridge
-    if let Some(forwarding_interface) = links.values().find(|e| e.if_name == forwarding_if_name)
+    if let Some(forwarding_interface) = links.values().find(|e| e.if_name == bridge_child_if_name)
         && forwarding_interface.link_kind.as_deref() == Some("veth")
         && forwarding_interface.bridge_if_index.is_none()
         && let Some(pair_if_index) = forwarding_interface.link_if_index
         && let Some(pair_interface) = links.get(&pair_if_index)
     {
-        forwarding_if_name = pair_interface.if_name.as_str();
+        bridge_child_if_name = pair_interface.if_name.as_str();
     }
 
-    let bridge = match call_ovs_interface_to_bridge(forwarding_if_name).await {
+    let bridge = match call_ovs_interface_to_bridge(bridge_child_if_name).await {
         Ok(e) => e,
         Err(e) => {
             debug!(%e, "ovs bridge not available");
@@ -210,7 +212,7 @@ async fn filter_interfaces_by_ovs_bridge(
     };
 
     debug!("filtering interfaces by {bridge:?} ovs bridge");
-    links.retain(|_, e| interfaces.contains(&e.if_name));
+    links.retain(|_, e| e.if_name == forwarding_if_name || interfaces.contains(&e.if_name));
     true
 }
 
@@ -245,8 +247,67 @@ fn filter_interfaces_by_linux_bridge(
 
     debug!("filtering interfaces by {:?} Linux bridge", bridge.if_name);
     let bridge_if_index = bridge.if_index as u32;
-    links.retain(|_, e| e.bridge_if_index == Some(bridge_if_index));
+    links.retain(|_, e| {
+        e.if_name == forwarding_if_name || e.bridge_if_index == Some(bridge_if_index)
+    });
     true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WirelessRadioBss {
+    pub radio_unique_id: MacAddr,
+    pub bss_list: Vec<WirelessBssInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WirelessBssInfo {
+    pub bssid: MacAddr,
+    pub ssid: Vec<u8>,
+}
+
+pub async fn get_ap_operational_radios() -> anyhow::Result<Vec<WirelessRadioBss>> {
+    let (router, _) = NlRouter::connect(NlFamily::Generic, None, Groups::empty()).await?;
+    let nl80211_family = router.resolve_genl_family(NL80211_GENL_NAME).await?;
+
+    let interfaces = call_nl80211_get_interfaces(&router, nl80211_family).await?;
+    let phy_map = call_nl80211_get_wiphy(&router, nl80211_family).await?;
+
+    let mut radios = IndexMap::new();
+    for interface in interfaces {
+        if !matches!(interface.if_type, Some(Nl80211IfType::Ap)) {
+            continue;
+        }
+        let Some(phy) = phy_map.get(&interface.phy_index) else {
+            continue;
+        };
+        let Some(phy_perm_addr) = phy.perm_addr else {
+            continue;
+        };
+
+        let ssid = interface.ssid.unwrap_or_default();
+        let radio = radios
+            .entry(interface.phy_index)
+            .or_insert_with(|| WirelessRadioBss {
+                radio_unique_id: phy_perm_addr,
+                bss_list: Vec::new(),
+            });
+
+        if !interface.mlo_link_macs.is_empty() {
+            for bssid in interface.mlo_link_macs {
+                radio.bss_list.push(WirelessBssInfo {
+                    bssid,
+                    ssid: ssid.clone(),
+                });
+            }
+        } else {
+            radio.bss_list.push(WirelessBssInfo {
+                bssid: interface.mac,
+                ssid,
+            });
+        }
+    }
+
+    Ok(radios.into_values().collect())
 }
 
 #[derive(Debug)]
@@ -534,6 +595,8 @@ struct WirelessInterfaceInfo {
     if_index: i32,
     if_name: String,
     if_type: Option<Nl80211IfType>,
+    ssid: Option<Vec<u8>>,
+    mlo_link_macs: Vec<MacAddr>,
     frequency: u32,
     channel_width: Option<Nl80211ChannelWidth>,
     center_freq_index1: Option<u8>,
@@ -589,10 +652,26 @@ async fn call_nl80211_get_interfaces(
         };
 
         let if_type = handle.get_attr_payload_as(Nl80211Attribute::IfType).ok();
+        let ssid = handle.get_attr_payload_as_with_len(Nl80211Attribute::Ssid);
         let frequency = handle.get_attr_payload_as(Nl80211Attribute::WiphyFreq);
         let channel_width = handle.get_attr_payload_as(Nl80211Attribute::ChannelWidth);
         let center_freq1 = handle.get_attr_payload_as(Nl80211Attribute::CenterFreq1);
         let center_freq2 = handle.get_attr_payload_as(Nl80211Attribute::CenterFreq2);
+        
+        let mut mlo_links = Vec::new();
+        if let Ok(links) = handle.get_nested_attributes::<u16>(Nl80211Attribute::MloLinks) {
+            for link in links.iter() {
+                let Ok(handle) = link.get_attr_handle::<Nl80211Attribute>() else {
+                    continue;
+                };
+                let Ok(mac) = handle.get_attr_payload_as::<[u8; 6]>(Nl80211Attribute::Mac) else {
+                    continue;
+                };
+                let link_id = *link.nla_type().nla_type();
+                mlo_links.push((link_id, MacAddr::from(mac)));
+            }
+            mlo_links.sort_by_key(|(link_id, _)| *link_id);
+        }
 
         interfaces.push(WirelessInterfaceInfo {
             mac: MacAddr::from(mac),
@@ -600,6 +679,8 @@ async fn call_nl80211_get_interfaces(
             if_index,
             if_name,
             if_type,
+            ssid: ssid.ok(),
+            mlo_link_macs: mlo_links.into_iter().map(|(_, mac)| mac).collect(),
             frequency: frequency.unwrap_or(0),
             channel_width: channel_width.ok(),
             center_freq_index1: center_freq1.ok().and_then(get_wifi_center_frequency_index),
@@ -717,6 +798,7 @@ async fn call_nl80211_get_survey(
 
 #[derive(Debug, Default)]
 struct WirelessPhyInfo {
+    perm_addr: Option<MacAddr>,
     bands: IndexMap<Nl80211Band, WirelessPhyBand>,
 }
 
@@ -766,6 +848,17 @@ async fn call_nl80211_get_wiphy(
         let handle = payload.attrs().get_attr_handle();
         let index = handle.get_attr_payload_as::<u32>(Nl80211Attribute::Wiphy)?;
         let phy = result.entry(index).or_insert_with(WirelessPhyInfo::default);
+
+        // The wiphy permanent MAC (perm_addr) is reported as NL80211_ATTR_MAC in
+        // the GetWiphy dump on Linux >= 5.4 (in any chunk of the split dump; the
+        // kernel emits it unconditionally, so all-zero values must be skipped).
+        if phy.perm_addr.is_none()
+            && let Ok(mac) = handle.get_attr_payload_as::<[u8; 6]>(Nl80211Attribute::Mac)
+            && let mac = MacAddr::from(mac)
+            && mac != MacAddr::zero()
+        {
+            phy.perm_addr = Some(mac);
+        }
 
         let bands = handle.get_nested_attributes::<Nl80211Band>(Nl80211Attribute::WiphyBands);
         for band in bands.ok().iter().flat_map(|e| e.iter()) {

--- a/ieee1905-core/src/linux/nl80211.rs
+++ b/ieee1905-core/src/linux/nl80211.rs
@@ -235,6 +235,10 @@ pub enum Nl80211Attribute {
     /// association request when used with NL80211_CMD_NEW_STATION). Can be set
     /// only if %NL80211_STA_FLAG_WME is set.
     EhtCapability = 310,
+    /// nested attribute with the links of an MLD (Wi-Fi 7 multi-link device);
+    /// one nested attribute per link with nla_type = link id + 1, each
+    /// containing e.g. the link address as %NL80211_ATTR_MAC
+    MloLinks = 312,
 }
 impl NlAttrType for Nl80211Attribute {}
 

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -26,7 +26,7 @@ use crate::artifact_exchange_service::client::{
 use crate::cmdu_codec::{
     ControlUrl, Ipv4, Ipv6, LinkMetricRx, LinkMetricRxPair, LinkMetricTx, LinkMetricTxPair,
 };
-use crate::interface_manager::get_interfaces;
+use crate::interface_manager::{WirelessRadioBss, get_ap_operational_radios, get_interfaces};
 use crate::linux::if_link::RtnlLinkStats64;
 use crate::lldpdu::PortId;
 use crate::{
@@ -552,6 +552,7 @@ pub struct TopologyDatabase {
     pub interface_name: String,
     pub local_mac: Arc<RwLock<MacAddr>>,
     pub local_interface_list: Arc<RwLock<Option<Vec<Ieee1905LocalInterface>>>>,
+    pub ap_operational_bss: Arc<RwLock<Vec<WirelessRadioBss>>>,
     pub nodes: Arc<RwLock<IndexMap<MacAddr, Ieee1905NodeInternal>>>,
     pub local_role: Arc<RwLock<Option<Role>>>,
     artifact_exchange_client_factory: Mutex<Option<ArtifactExchangeClientFactory>>,
@@ -575,6 +576,7 @@ impl TopologyDatabase {
             interface_name,
             local_mac: Arc::new(RwLock::new(local_mac)),
             local_interface_list: Arc::new(RwLock::new(None)),
+            ap_operational_bss: Default::default(),
             nodes: Arc::new(RwLock::new(IndexMap::new())),
             local_role: Arc::new(RwLock::new(None)),
             artifact_exchange_client_factory: Default::default(),
@@ -800,6 +802,11 @@ impl TopologyDatabase {
                 Err(e) => {
                     error!("Interface scan task panicked: {:?}", e);
                 }
+            }
+
+            match get_ap_operational_radios().await {
+                Ok(radios) => *self.ap_operational_bss.write().await = radios,
+                Err(e) => warn!(%e, "get_ap_operational_radios failed"),
             }
 
             *self.local_mac.write().await = get_forwarding_interface_mac(&self.interface_name);


### PR DESCRIPTION
# ApOperationalBss
<img width="718" height="451" alt="image" src="https://github.com/user-attachments/assets/b4082c8c-5788-462d-bcb8-6c9542fa7d33" />

# BssConfigurationReport
<img width="631" height="489" alt="image" src="https://github.com/user-attachments/assets/d918f0ce-8c0d-46c7-bdfe-14a893e1507d" />

[ieee1905_bss.pcapng.zip](https://github.com/user-attachments/files/30219234/ieee1905_bss.pcapng.zip)
