### PR TITLE
[#429] Return multiple transmission events from topology state machine

### DIFF
--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -271,7 +271,7 @@ impl CMDUHandler {
             ..Default::default()
         };
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 device_data,
                 UpdateType::DiscoveryReceived,
@@ -288,44 +288,39 @@ impl CMDUHandler {
             "Topology Discovery Processed",
         );
 
-        // Now react to the event
-        match transmission_event {
-            TransmissionEvent::SendTopologyQuery(destination_al_mac) => {
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_topo_query/{destination_al_mac}"),
-                    cmdu_topology_query_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        self.local_al_mac,
-                        destination_al_mac,
-                        forwarding_interface_mac,
-                    ),
-                );
-            }
-            TransmissionEvent::StartHigherLayerQueryWorker((destination, token)) => {
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_hle_query/{destination}"),
-                    cmdu_higher_layer_query_transmission_worker(
-                        topology_db.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        forwarding_interface_mac,
-                        destination,
-                        token,
-                    ),
-                );
-            }
-            TransmissionEvent::None => {
-                debug!(
-                    remote = %remote_al_mac,
-                    "No transmission needed after topology discovery update"
-                );
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_discovery");
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyQuery(destination_al_mac) => {
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                    spawn_named(
+                        format!("proxy_topo_query/{destination_al_mac}"),
+                        cmdu_topology_query_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            self.local_al_mac,
+                            destination_al_mac,
+                            forwarding_interface_mac,
+                        ),
+                    );
+                }
+                TransmissionEvent::StartHigherLayerQueryWorker((destination, token)) => {
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                    spawn_named(
+                        format!("proxy_hle_query/{destination}"),
+                        cmdu_higher_layer_query_transmission_worker(
+                            topology_db.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            forwarding_interface_mac,
+                            destination,
+                            token,
+                        ),
+                    );
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_discovery");
+                }
             }
         }
     }
@@ -374,7 +369,7 @@ impl CMDUHandler {
         let remote_al_mac = device_data.al_mac;
         let has_vendor_info = VendorSpecificInfo::find(tlvs).is_some_and(|e| e.oui == COMCAST_OUI);
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 device_data,
                 UpdateType::QueryReceived {
@@ -392,41 +387,37 @@ impl CMDUHandler {
             "Topology Query Processed",
         );
 
-        match transmission_event {
-            TransmissionEvent::SendTopologyResponse(destination_mac) => {
-                debug!(
-                    remote = %remote_al_mac,
-                    local = %self.local_al_mac,
-                    "Preparing to send Topology Response"
-                );
+        let mut sent_response = false;
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyResponse(destination_mac) => {
+                    debug!(
+                        remote = %remote_al_mac,
+                        local = %self.local_al_mac,
+                        "Preparing to send Topology Response"
+                    );
 
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
 
-                spawn_named(
-                    format!("proxy_topo_response/{destination_mac}"),
-                    cmdu_topology_response_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.local_al_mac,
-                        destination_mac,
-                        forwarding_interface_mac,
-                        message_id,
-                    ),
-                );
-                true
-            }
-            TransmissionEvent::None => {
-                debug!(
-                    remote = %remote_al_mac,
-                    "No transmission needed after topology query update"
-                );
-                false
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_query");
-                false
+                    spawn_named(
+                        format!("proxy_topo_response/{destination_mac}"),
+                        cmdu_topology_response_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.local_al_mac,
+                            destination_mac,
+                            forwarding_interface_mac,
+                            message_id,
+                        ),
+                    );
+                    sent_response = true;
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_query");
+                }
             }
         }
+        sent_response
     }
 
     /// Handles and logs TLVs for Topology Response.
@@ -548,7 +539,7 @@ impl CMDUHandler {
             ..Default::default()
         };
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 updated_device_data,
                 UpdateType::ResponseReceived,
@@ -565,41 +556,36 @@ impl CMDUHandler {
             "Topology Response Processed",
         );
 
-        match transmission_event {
-            TransmissionEvent::SendTopologyNotification(_destination_mac) => {
-                debug!(
-                    al_mac = %remote_al_mac,
-                    source = %source_mac,
-                    "Sending Topology Notification because topology changed"
-                );
+        let mut sent_notification = false;
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyNotification(_destination_mac) => {
+                    debug!(
+                        al_mac = %remote_al_mac,
+                        source = %source_mac,
+                        "Sending Topology Notification because topology changed"
+                    );
 
-                let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
+                    let forwarding_interface_mac = topology_db.get_forwarding_interface_mac().await;
 
-                spawn_named(
-                    "proxy_topo_notification",
-                    cmdu_topology_notification_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        self.local_al_mac,
-                        forwarding_interface_mac,
-                    ),
-                );
-                true
-            }
-            TransmissionEvent::None => {
-                debug!(
-                    al_mac = %remote_al_mac,
-                    source = %source_mac,
-                    "Topology update did not require sending notification"
-                );
-                false
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_response");
-                false
+                    spawn_named(
+                        "proxy_topo_notification",
+                        cmdu_topology_notification_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            self.local_al_mac,
+                            forwarding_interface_mac,
+                        ),
+                    );
+                    sent_notification = true;
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_response");
+                }
             }
         }
+        sent_notification
     }
 
     /// Handles and logs TLVs from the CMDU payload for Topology Notification.
@@ -643,7 +629,7 @@ impl CMDUHandler {
             ..Default::default()
         };
 
-        let transmission_event = topology_db
+        let transmission_events = topology_db
             .update_ieee1905_topology(
                 received_device_data,
                 UpdateType::NotificationReceived,
@@ -659,31 +645,30 @@ impl CMDUHandler {
             "Topology Notification Processed",
         );
 
-        match transmission_event {
-            TransmissionEvent::SendTopologyQuery(dest_mac) => {
-                let forwarding_interface = topology_db.get_forwarding_interface_mac().await;
-                spawn_named(
-                    format!("proxy_topo_query/{remote_al_mac_address}"),
-                    cmdu_topology_query_transmission(
-                        self.interface_name.clone(),
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        self.local_al_mac,
-                        dest_mac,
-                        forwarding_interface,
-                    ),
-                );
-                true
-            }
-            TransmissionEvent::None => {
-                debug!("No transmission event triggered by Topology Notification");
-                false
-            }
-            _ => {
-                warn!("Unexpected TransmissionEvent in handle_topology_notification");
-                false
+        let mut sent_query = false;
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::SendTopologyQuery(dest_mac) => {
+                    let forwarding_interface = topology_db.get_forwarding_interface_mac().await;
+                    spawn_named(
+                        format!("proxy_topo_query/{remote_al_mac_address}"),
+                        cmdu_topology_query_transmission(
+                            self.interface_name.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            self.local_al_mac,
+                            dest_mac,
+                            forwarding_interface,
+                        ),
+                    );
+                    sent_query = true;
+                }
+                _ => {
+                    warn!("Unexpected TransmissionEvent in handle_topology_notification");
+                }
             }
         }
+        sent_query
     }
 
     /// Handles and logs TLVs for Link Metric Query.
@@ -782,7 +767,7 @@ impl CMDUHandler {
         };
 
         let topo_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
-        let transmission_event = topo_db
+        let transmission_events = topo_db
             .update_ieee1905_topology(
                 device_data,
                 UpdateType::ApAutoConfigSearch,
@@ -792,33 +777,31 @@ impl CMDUHandler {
             )
             .await;
 
-        match transmission_event {
-            TransmissionEvent::StartLinkMetricQueryWorker((destination, cancellation_token)) => {
-                debug!(
-                    al_mac = %al_mac.al_mac_address,
-                    source = %source_mac,
-                    "Topology update started link metric query worker"
-                );
-                spawn_named(
-                    format!("proxy_link_metric_query/{destination}"),
-                    cmdu_link_metric_query_transmission_worker(
-                        topo_db,
-                        self.sender.clone(),
-                        self.message_id_generator.clone(),
-                        local_interface_mac,
-                        destination,
-                        cancellation_token,
-                    ),
-                );
+        for transmission_event in transmission_events {
+            match transmission_event {
+                TransmissionEvent::StartLinkMetricQueryWorker((
+                    destination,
+                    cancellation_token,
+                )) => {
+                    debug!(
+                        al_mac = %al_mac.al_mac_address,
+                        source = %source_mac,
+                        "Topology update started link metric query worker"
+                    );
+                    spawn_named(
+                        format!("proxy_link_metric_query/{destination}"),
+                        cmdu_link_metric_query_transmission_worker(
+                            topo_db.clone(),
+                            self.sender.clone(),
+                            self.message_id_generator.clone(),
+                            local_interface_mac,
+                            destination,
+                            cancellation_token,
+                        ),
+                    );
+                }
+                _ => warn!("Unexpected TransmissionEvent in handle_ap_auto_config_search"),
             }
-            TransmissionEvent::None => {
-                debug!(
-                    al_mac = %al_mac.al_mac_address,
-                    source = %source_mac,
-                    "Topology update did not require sending notification"
-                );
-            }
-            _ => warn!("Unexpected TransmissionEvent in handle_ap_auto_config_search"),
         }
 
         info!(source = %source_mac, "ApAutoConfigSearch Processed");

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -102,7 +102,6 @@ pub enum TransmissionEvent {
     SendTopologyNotification(MacAddr),
     StartLinkMetricQueryWorker((MacAddr, CancellationToken)),
     StartHigherLayerQueryWorker((MacAddr, CancellationToken)),
-    None,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -473,34 +472,38 @@ impl Ieee1905NodeInternal {
         }
     }
 
-    fn prepare_link_metrics_query_transmission_event_if_needed(&mut self) -> TransmissionEvent {
+    fn prepare_link_metrics_query_transmission_event_if_needed(
+        &mut self,
+    ) -> Option<TransmissionEvent> {
         if self.link_metrics_query_cancellation_token.is_some() {
-            return TransmissionEvent::None;
+            return None;
         }
 
         let cancellation_token = CancellationToken::new();
         let drop_guard = cancellation_token.clone().drop_guard();
         self.link_metrics_query_cancellation_token = Some(drop_guard);
 
-        TransmissionEvent::StartLinkMetricQueryWorker((
+        Some(TransmissionEvent::StartLinkMetricQueryWorker((
             self.device_data.destination_frame_mac,
             cancellation_token,
-        ))
+        )))
     }
 
-    fn prepare_higher_layer_query_transmission_event_if_needed(&mut self) -> TransmissionEvent {
+    fn prepare_higher_layer_query_transmission_event_if_needed(
+        &mut self,
+    ) -> Option<TransmissionEvent> {
         if self.higher_layer_query_cancellation_token.is_some() {
-            return TransmissionEvent::None;
+            return None;
         }
 
         let cancellation_token = CancellationToken::new();
         let drop_guard = cancellation_token.clone().drop_guard();
         self.higher_layer_query_cancellation_token = Some(drop_guard);
 
-        TransmissionEvent::StartHigherLayerQueryWorker((
+        Some(TransmissionEvent::StartHigherLayerQueryWorker((
             self.device_data.destination_frame_mac,
             cancellation_token,
-        ))
+        )))
     }
 
     fn update_artifact_exchange_client(
@@ -822,9 +825,9 @@ impl TopologyDatabase {
         local_msg_id: Option<u16>,
         remote_msg_id: Option<u16>,
         lldp_neighbor: Option<PortId>,
-    ) -> TransmissionEvent {
+    ) -> Vec<TransmissionEvent> {
         let al_mac = device_data.al_mac;
-        let transmission_event;
+        let transmission_events;
 
         //TODO: use new update types.
         tracing::debug!("WAITING for write lock");
@@ -838,7 +841,7 @@ impl TopologyDatabase {
 
                     node.device_data.local_interface_mac = device_data.local_interface_mac;
 
-                    transmission_event = match operation {
+                    transmission_events = match operation {
                         UpdateType::DiscoveryReceived => {
                             let local_state = node.metadata.node_state_local;
 
@@ -853,9 +856,13 @@ impl TopologyDatabase {
                             );
 
                             if local_state == StateLocal::Idle {
-                                TransmissionEvent::SendTopologyQuery(al_mac)
+                                vec![TransmissionEvent::SendTopologyQuery(al_mac)]
                             } else {
-                                node.prepare_higher_layer_query_transmission_event_if_needed()
+                                let mut events = Vec::new();
+                                events.extend(
+                                    node.prepare_higher_layer_query_transmission_event_if_needed(),
+                                );
+                                events
                             }
                         }
                         UpdateType::NotificationReceived => {
@@ -870,9 +877,9 @@ impl TopologyDatabase {
                                     Some(StateLocal::Idle),
                                     None,
                                 );
-                                TransmissionEvent::SendTopologyQuery(al_mac)
+                                vec![TransmissionEvent::SendTopologyQuery(al_mac)]
                             } else {
-                                TransmissionEvent::None
+                                vec![]
                             }
                         }
                         UpdateType::QueryReceived { force } => {
@@ -888,9 +895,9 @@ impl TopologyDatabase {
                                     Some(StateRemote::ConvergingRemote(Instant::now())),
                                 );
                                 debug!("Event: Send Topology Response");
-                                TransmissionEvent::SendTopologyResponse(al_mac)
+                                vec![TransmissionEvent::SendTopologyResponse(al_mac)]
                             } else {
-                                TransmissionEvent::None
+                                vec![]
                             }
                         }
 
@@ -925,14 +932,14 @@ impl TopologyDatabase {
                                     let multicast_mac =
                                         MacAddr::new(0x01, 0x80, 0xC2, 0x00, 0x00, 0x13);
                                     debug!("Event: Send Topology Notification");
-                                    TransmissionEvent::SendTopologyNotification(multicast_mac)
+                                    vec![TransmissionEvent::SendTopologyNotification(multicast_mac)]
                                 } else {
-                                    debug!("Device data unchanged — no transmission needed");
-                                    TransmissionEvent::None
+                                    debug!("Device data unchanged");
+                                    vec![]
                                 }
                             } else {
                                 debug!("Ignoring ResponseReceived — not in ConvergingLocal state");
-                                TransmissionEvent::None
+                                vec![]
                             }
                         }
 
@@ -947,7 +954,7 @@ impl TopologyDatabase {
                                     None,
                                 );
                             }
-                            TransmissionEvent::None
+                            vec![]
                         }
                         UpdateType::ResponseSent => {
                             if let StateRemote::ConvergingRemote(_) =
@@ -962,7 +969,7 @@ impl TopologyDatabase {
                                     Some(StateRemote::ConvergedRemote),
                                 );
                             }
-                            TransmissionEvent::None
+                            vec![]
                         }
                         UpdateType::LldpUpdate => {
                             node.metadata.update(
@@ -974,13 +981,14 @@ impl TopologyDatabase {
                                 None,
                             );
                             debug!(al_mac = ?al_mac, lldp_neighbor = ?lldp_neighbor, "Updated LLDP neighbor status");
-                            TransmissionEvent::None
+                            vec![]
                             //If needed we can indicate here a notification event to update topology data base in al neighbors but for now it is not needed
                             //initial DB snapshot covers current uses cases for RDK-B but we can update this part if needed in the future
                         }
-                        UpdateType::ApAutoConfigSearch => {
-                            node.prepare_link_metrics_query_transmission_event_if_needed()
-                        }
+                        UpdateType::ApAutoConfigSearch => node
+                            .prepare_link_metrics_query_transmission_event_if_needed()
+                            .into_iter()
+                            .collect(),
                     };
                 }
                 None => {
@@ -1006,12 +1014,12 @@ impl TopologyDatabase {
                     };
 
                     let node_was_created;
-                    transmission_event = match operation {
+                    transmission_events = match operation {
                         UpdateType::DiscoveryReceived => {
                             nodes.insert(al_mac, new_node);
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from Discovery");
-                            TransmissionEvent::SendTopologyQuery(al_mac)
+                            vec![TransmissionEvent::SendTopologyQuery(al_mac)]
                         }
                         UpdateType::QueryReceived { .. } => {
                             new_node.metadata.node_state_remote =
@@ -1019,18 +1027,20 @@ impl TopologyDatabase {
                             nodes.insert(al_mac, new_node);
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from query");
-                            TransmissionEvent::SendTopologyResponse(al_mac)
+                            vec![TransmissionEvent::SendTopologyResponse(al_mac)]
                         }
                         UpdateType::ApAutoConfigSearch => {
                             let node = nodes.entry(al_mac).insert_entry(new_node).into_mut();
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from ApAutoConfigSearch");
                             node.prepare_link_metrics_query_transmission_event_if_needed()
+                                .into_iter()
+                                .collect()
                         }
                         _ => {
                             debug!(al_mac = ?al_mac, operation = ?operation, "Insertion skipped — unsupported operation");
                             node_was_created = false;
-                            TransmissionEvent::None
+                            vec![]
                         }
                     };
 
@@ -1045,7 +1055,7 @@ impl TopologyDatabase {
         }
 
         debug!("Lock released — function continues safely");
-        transmission_event
+        transmission_events
     }
 
     pub async fn handle_notification_sent(&self) {


### PR DESCRIPTION
- Update `TopologyDatabase::update_ieee1905_topology` to return `Vec<TransmissionEvent>`
- Replace `TransmissionEvent::None` with an empty event vector
- Update CMDU handlers to process all returned transmission events