### PR TITLE
[#15] Track registrar status for topology nodes

### DIFF
--- a/ieee1905-core/src/cmdu_codec.rs
+++ b/ieee1905-core/src/cmdu_codec.rs
@@ -1103,23 +1103,21 @@ pub struct SearchedRole {
     pub role: u8,
 }
 
+impl SearchedRole {
+    pub const TYPE_REGISTRAR: u8 = 0x00;
+}
+
 impl TLVTrait for SearchedRole {
     const TYPE: IEEE1905TLVType = IEEE1905TLVType::SearchedRole;
 
     fn parse(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, role_bytes) = take(1usize)(input)?;
-        let role = role_bytes[0];
+        let (input, role) = be_u8(input)?;
 
-        if role != 0x00 {
+        if role != Self::TYPE_REGISTRAR {
             return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
         }
 
-        Ok((
-            input,
-            Self {
-                role: role_bytes[0],
-            },
-        ))
+        Ok((input, Self { role }))
     }
 
     fn serialize(&self) -> Vec<u8> {
@@ -1133,14 +1131,17 @@ pub struct SupportedRole {
     pub role: u8,
 }
 
+impl SupportedRole {
+    pub const TYPE_REGISTRAR: u8 = 0x00;
+}
+
 impl TLVTrait for SupportedRole {
     const TYPE: IEEE1905TLVType = IEEE1905TLVType::SupportedRole;
 
     fn parse(input: &[u8]) -> IResult<&[u8], Self> {
-        let (input, role_bytes) = take(1usize)(input)?;
-        let role = role_bytes[0];
+        let (input, role) = be_u8(input)?;
 
-        if role != 0x00 {
+        if role != Self::TYPE_REGISTRAR {
             return Err(nom::Err::Failure(Error::new(input, ErrorKind::Verify)));
         }
 
@@ -1962,7 +1963,7 @@ impl MediaTypeSpecialInfo {
             MediaTypeSpecialInfo::Other(_) => None,
         }
     }
-    
+
     pub fn parse(media_type: MediaType, input: &[u8]) -> IResult<&[u8], Self> {
         if (0x0100..0x0108).contains(&media_type.0) {
             // Wifi6 and Wifi7 don't have extras

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -763,15 +763,15 @@ impl CMDUHandler {
             al_mac: al_mac.al_mac_address,
             destination_frame_mac: source_mac,
             local_interface_mac,
+            registrar: SearchedRole::find(tlvs).map(|_| false),
             ..Default::default()
         };
-        let registrar = SearchedRole::find(tlvs).map(|_| false);
 
         let topo_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
         let transmission_events = topo_db
             .update_ieee1905_topology(
                 device_data,
-                UpdateType::ApAutoConfigSearch { registrar },
+                UpdateType::ApAutoConfigSearch,
                 None,
                 Some(message_id),
                 None,
@@ -823,28 +823,19 @@ impl CMDUHandler {
             "Handling ApAutoConfigResponse CMDU",
         );
 
-        let topo_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
-        let registrar = SupportedRole::find(tlvs).map(|_| true);
-        if registrar.is_some()
-            && let Some(node) = topo_db.find_device_by_port(source_mac).await
-        {
-            topo_db
-                .update_ieee1905_topology(
-                    node.device_data,
-                    UpdateType::ApAutoConfigResponse { registrar },
-                    None,
-                    None,
-                    None,
-                )
-                .await;
-        }
-
+        let Some(supported_role) = SupportedRole::find(tlvs) else {
+            return error!("ApAutoConfigResponse CMDU missing SupportedRole TLV");
+        };
         let Some(supported_freq_band) = SupportedFreqBand::find(tlvs) else {
             return error!("ApAutoConfigResponse CMDU missing SupportedFreqBand TLV");
         };
 
-        topo_db
-            .handle_ap_auto_config_response(source_mac, supported_freq_band)
+        TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
+            .handle_ap_auto_config_response(
+                source_mac,
+                supported_role,
+                supported_freq_band,
+            )
             .await;
 
         info!(source = %source_mac, "ApAutoConfigResponse Processed");

--- a/ieee1905-core/src/cmdu_handler.rs
+++ b/ieee1905-core/src/cmdu_handler.rs
@@ -765,12 +765,13 @@ impl CMDUHandler {
             local_interface_mac,
             ..Default::default()
         };
+        let registrar = SearchedRole::find(tlvs).map(|_| false);
 
         let topo_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
         let transmission_events = topo_db
             .update_ieee1905_topology(
                 device_data,
-                UpdateType::ApAutoConfigSearch,
+                UpdateType::ApAutoConfigSearch { registrar },
                 None,
                 Some(message_id),
                 None,
@@ -822,11 +823,27 @@ impl CMDUHandler {
             "Handling ApAutoConfigResponse CMDU",
         );
 
+        let topo_db = TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name);
+        let registrar = SupportedRole::find(tlvs).map(|_| true);
+        if registrar.is_some()
+            && let Some(node) = topo_db.find_device_by_port(source_mac).await
+        {
+            topo_db
+                .update_ieee1905_topology(
+                    node.device_data,
+                    UpdateType::ApAutoConfigResponse { registrar },
+                    None,
+                    None,
+                    None,
+                )
+                .await;
+        }
+
         let Some(supported_freq_band) = SupportedFreqBand::find(tlvs) else {
             return error!("ApAutoConfigResponse CMDU missing SupportedFreqBand TLV");
         };
 
-        TopologyDatabase::get_instance(self.local_al_mac, &self.interface_name)
+        topo_db
             .handle_ap_auto_config_response(source_mac, supported_freq_band)
             .await;
 

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -936,7 +936,7 @@ pub async fn cmdu_from_sdu_transmission(interface: String, sender: Arc<EthernetS
                 _ => None,
             };
 
-            if expected_local_role == topology_db.get_local_role().await {
+if expected_local_role.is_some() && expected_local_role == topology_db.get_local_role().await {
                 match cmdu.get_tlvs() {
                     Ok(mut tlvs) => {
                         if let Err(e) = inject_ap_autoconfig_role_tlv(&mut tlvs, cmdu.message_type)

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -918,38 +918,41 @@ pub async fn cmdu_from_sdu_transmission(interface: String, sender: Arc<EthernetS
                 }
             };
 
-            if cmdu.message_type == CMDUType::TopologyResponse.to_u16() {
-                let Ok(mut tlvs) = cmdu.get_tlvs() else {
-                    return error!("Failed to parse topo response TLVs");
-                };
-                if let Err(e) = inject_topology_response_tlvs(&mut tlvs, &topology_db).await {
-                    return error!(%e, "Failed to inject topo response TLVs");
-                }
-                debug!("injecting topology response TLVs");
-                cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
-                trace!(?cmdu, "injected topology response TLVs");
-            }
-
-            let expected_local_role = match CMDUType::from_u16(cmdu.message_type) {
-                CMDUType::ApAutoConfigSearch => Some(Role::Enrollee),
-                CMDUType::ApAutoConfigResponse => Some(Role::Registrar),
-                _ => None,
-            };
-
-if expected_local_role.is_some() && expected_local_role == topology_db.get_local_role().await {
-                match cmdu.get_tlvs() {
-                    Ok(mut tlvs) => {
-                        if let Err(e) = inject_ap_autoconfig_role_tlv(&mut tlvs, cmdu.message_type)
-                        {
-                            error!(%e, "Failed to inject AP-autoconfiguration role TLV");
-                        } else {
-                            cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
-                        }
+            match CMDUType::from_u16(cmdu.message_type) {
+                CMDUType::TopologyResponse => {
+                    let Ok(mut tlvs) = cmdu.get_tlvs() else {
+                        return error!("Failed to parse TopologyResponse TLVs");
+                    };
+                    if let Err(e) = inject_topology_response_tlvs(&mut tlvs, &topology_db).await {
+                        return error!(%e, "Failed to inject topo response TLVs");
                     }
-                    Err(e) => {
-                        error!(%e, "Failed to parse AP-autoconfiguration TLVs");
-                    }
+                    debug!("injecting TopologyResponse TLVs");
+                    cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
+                    trace!(?cmdu, "injected TopologyResponse TLVs");
                 }
+                CMDUType::ApAutoConfigSearch
+                    if topology_db.get_local_role().await == Some(Role::Enrollee) =>
+                {
+                    let Ok(mut tlvs) = cmdu.get_tlvs() else {
+                        return error!("Failed to parse ApAutoConfigSearch TLVs");
+                    };
+                    inject_ap_autoconfig_search_tlvs(&mut tlvs);
+                    debug!("injecting ApAutoConfigSearch TLVs");
+                    cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
+                    trace!(?cmdu, "injected ApAutoConfigSearch TLVs");
+                }
+                CMDUType::ApAutoConfigResponse
+                    if topology_db.get_local_role().await == Some(Role::Registrar) =>
+                {
+                    let Ok(mut tlvs) = cmdu.get_tlvs() else {
+                        return error!("Failed to parse ApAutoConfigResponse TLVs");
+                    };
+                    inject_ap_autoconfig_response_tlvs(&mut tlvs);
+                    debug!("injecting ApAutoConfigResponse TLVs");
+                    cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
+                    trace!(?cmdu, "injected ApAutoConfigResponse TLVs");
+                }
+                _ => {}
             }
 
             if let Err(e) =
@@ -965,41 +968,40 @@ if expected_local_role.is_some() && expected_local_role == topology_db.get_local
     }
 }
 
-fn inject_ap_autoconfig_role_tlv(vec: &mut Vec<TLV>, message_type: u16) -> anyhow::Result<()> {
-    let (role_tlv, insert_after_al_mac) = match CMDUType::from_u16(message_type) {
-        CMDUType::ApAutoConfigSearch => (TLV::from(SearchedRole { role: 0x00 }), true),
-        CMDUType::ApAutoConfigResponse => (TLV::from(SupportedRole { role: 0x00 }), false),
-        _ => return Ok(()),
-    };
-
-    if vec.iter().any(|tlv| tlv.tlv_type == role_tlv.tlv_type) {
-        return Ok(());
+fn inject_ap_autoconfig_search_tlvs(vec: &mut Vec<TLV>) {
+    let tlv_type = SearchedRole::TYPE.to_u8();
+    if vec.iter().any(|tlv| tlv.tlv_type == tlv_type) {
+        return;
     }
 
-    let Some(end_of_message_tlv) = vec.pop() else {
-        anyhow::bail!("EndOfMessage TLV was not found");
-    };
+    let position = vec
+        .iter()
+        .position(|tlv| tlv.tlv_type == AlMacAddress::TYPE.to_u8())
+        .map_or(0, |index| index + 1);
 
-    if end_of_message_tlv.tlv_type != EndOfMessage::TYPE.to_u8()
-        || end_of_message_tlv.tlv_length != 0
-    {
-        vec.push(end_of_message_tlv);
-        anyhow::bail!("TLV list doesn't end with EndOfMessage");
+    let tlv = TLV::from(SearchedRole {
+        role: SearchedRole::TYPE_REGISTRAR,
+    });
+
+    vec.insert(position, tlv);
+}
+
+fn inject_ap_autoconfig_response_tlvs(vec: &mut Vec<TLV>) {
+    let tlv_type = SupportedRole::TYPE.to_u8();
+    if vec.iter().any(|tlv| tlv.tlv_type == tlv_type) {
+        return;
     }
 
-    // Search - AL MAC, SearchedRole, AutoconfigFreqBand
-    // Response - SupportedRole, SupportedFreqBand
-    let insert_index = if insert_after_al_mac {
-        vec.iter()
-            .position(|tlv| tlv.tlv_type == AlMacAddress::TYPE.to_u8())
-            .map_or(vec.len(), |index| index + 1)
-    } else {
-        0
-    };
+    let position = vec
+        .iter()
+        .position(|tlv| tlv.tlv_type == SupportedFreqBand::TYPE.to_u8())
+        .unwrap_or(0);
 
-    vec.insert(insert_index, role_tlv);
-    vec.push(end_of_message_tlv);
-    Ok(())
+    let tlv = TLV::from(SupportedRole {
+        role: SupportedRole::TYPE_REGISTRAR,
+    });
+
+    vec.insert(position, tlv);
 }
 
 async fn enqueue_fragmented_cmdu(

--- a/ieee1905-core/src/cmdu_proxy.rs
+++ b/ieee1905-core/src/cmdu_proxy.rs
@@ -930,6 +930,28 @@ pub async fn cmdu_from_sdu_transmission(interface: String, sender: Arc<EthernetS
                 trace!(?cmdu, "injected topology response TLVs");
             }
 
+            let expected_local_role = match CMDUType::from_u16(cmdu.message_type) {
+                CMDUType::ApAutoConfigSearch => Some(Role::Enrollee),
+                CMDUType::ApAutoConfigResponse => Some(Role::Registrar),
+                _ => None,
+            };
+
+            if expected_local_role == topology_db.get_local_role().await {
+                match cmdu.get_tlvs() {
+                    Ok(mut tlvs) => {
+                        if let Err(e) = inject_ap_autoconfig_role_tlv(&mut tlvs, cmdu.message_type)
+                        {
+                            error!(%e, "Failed to inject AP-autoconfiguration role TLV");
+                        } else {
+                            cmdu.payload = tlvs.iter().flat_map(TLV::serialize).collect();
+                        }
+                    }
+                    Err(e) => {
+                        error!(%e, "Failed to parse AP-autoconfiguration TLVs");
+                    }
+                }
+            }
+
             if let Err(e) =
                 enqueue_fragmented_cmdu(&sender, destination_mac, source_mac, cmdu, fragmentation)
                     .await
@@ -941,6 +963,43 @@ pub async fn cmdu_from_sdu_transmission(interface: String, sender: Arc<EthernetS
             error!("Failed to parse CMDU from SDU payload!");
         }
     }
+}
+
+fn inject_ap_autoconfig_role_tlv(vec: &mut Vec<TLV>, message_type: u16) -> anyhow::Result<()> {
+    let (role_tlv, insert_after_al_mac) = match CMDUType::from_u16(message_type) {
+        CMDUType::ApAutoConfigSearch => (TLV::from(SearchedRole { role: 0x00 }), true),
+        CMDUType::ApAutoConfigResponse => (TLV::from(SupportedRole { role: 0x00 }), false),
+        _ => return Ok(()),
+    };
+
+    if vec.iter().any(|tlv| tlv.tlv_type == role_tlv.tlv_type) {
+        return Ok(());
+    }
+
+    let Some(end_of_message_tlv) = vec.pop() else {
+        anyhow::bail!("EndOfMessage TLV was not found");
+    };
+
+    if end_of_message_tlv.tlv_type != EndOfMessage::TYPE.to_u8()
+        || end_of_message_tlv.tlv_length != 0
+    {
+        vec.push(end_of_message_tlv);
+        anyhow::bail!("TLV list doesn't end with EndOfMessage");
+    }
+
+    // Search - AL MAC, SearchedRole, AutoconfigFreqBand
+    // Response - SupportedRole, SupportedFreqBand
+    let insert_index = if insert_after_al_mac {
+        vec.iter()
+            .position(|tlv| tlv.tlv_type == AlMacAddress::TYPE.to_u8())
+            .map_or(vec.len(), |index| index + 1)
+    } else {
+        0
+    };
+
+    vec.insert(insert_index, role_tlv);
+    vec.push(end_of_message_tlv);
+    Ok(())
 }
 
 async fn enqueue_fragmented_cmdu(

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -93,7 +93,8 @@ pub enum UpdateType {
     QueryReceived { force: bool },
     ResponseSent,
     ResponseReceived,
-    ApAutoConfigSearch,
+    ApAutoConfigSearch { registrar: Option<bool> },
+    ApAutoConfigResponse { registrar: Option<bool> },
 }
 
 pub enum TransmissionEvent {
@@ -357,6 +358,7 @@ pub struct Ieee1905DeviceData {
     pub local_interface_mac: MacAddr,
     pub local_interface_list: Option<Vec<Ieee1905InterfaceData>>,
     pub registry_role: Option<Role>,
+    pub registrar: bool,
     pub supported_fragmentation: CMDUFragmentation,
     pub supported_freq_band: Option<SupportedFreqBand>,
     pub ieee1905_profile_version: Ieee1905ProfileVersion,
@@ -985,10 +987,21 @@ impl TopologyDatabase {
                             //If needed we can indicate here a notification event to update topology data base in al neighbors but for now it is not needed
                             //initial DB snapshot covers current uses cases for RDK-B but we can update this part if needed in the future
                         }
-                        UpdateType::ApAutoConfigSearch => node
-                            .prepare_link_metrics_query_transmission_event_if_needed()
-                            .into_iter()
-                            .collect(),
+                        UpdateType::ApAutoConfigSearch { registrar } => {
+                            if let Some(registrar) = registrar {
+                                node.device_data.registrar = registrar;
+                            }
+
+                            node.prepare_link_metrics_query_transmission_event_if_needed()
+                                .into_iter()
+                                .collect()
+                        }
+                        UpdateType::ApAutoConfigResponse { registrar } => {
+                            if let Some(registrar) = registrar {
+                                node.device_data.registrar = registrar;
+                            }
+                            vec![]
+                        }
                     };
                 }
                 None => {
@@ -1029,7 +1042,7 @@ impl TopologyDatabase {
                             debug!(al_mac = ?al_mac, "Inserted node from query");
                             vec![TransmissionEvent::SendTopologyResponse(al_mac)]
                         }
-                        UpdateType::ApAutoConfigSearch => {
+                        UpdateType::ApAutoConfigSearch { .. } => {
                             let node = nodes.entry(al_mac).insert_entry(new_node).into_mut();
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from ApAutoConfigSearch");

--- a/ieee1905-core/src/topology_manager.rs
+++ b/ieee1905-core/src/topology_manager.rs
@@ -25,6 +25,7 @@ use crate::artifact_exchange_service::client::{
 };
 use crate::cmdu_codec::{
     ControlUrl, Ipv4, Ipv6, LinkMetricRx, LinkMetricRxPair, LinkMetricTx, LinkMetricTxPair,
+    SupportedRole,
 };
 use crate::interface_manager::get_interfaces;
 use crate::linux::if_link::RtnlLinkStats64;
@@ -93,8 +94,7 @@ pub enum UpdateType {
     QueryReceived { force: bool },
     ResponseSent,
     ResponseReceived,
-    ApAutoConfigSearch { registrar: Option<bool> },
-    ApAutoConfigResponse { registrar: Option<bool> },
+    ApAutoConfigSearch,
 }
 
 pub enum TransmissionEvent {
@@ -358,7 +358,7 @@ pub struct Ieee1905DeviceData {
     pub local_interface_mac: MacAddr,
     pub local_interface_list: Option<Vec<Ieee1905InterfaceData>>,
     pub registry_role: Option<Role>,
-    pub registrar: bool,
+    pub registrar: Option<bool>,
     pub supported_fragmentation: CMDUFragmentation,
     pub supported_freq_band: Option<SupportedFreqBand>,
     pub ieee1905_profile_version: Ieee1905ProfileVersion,
@@ -987,20 +987,17 @@ impl TopologyDatabase {
                             //If needed we can indicate here a notification event to update topology data base in al neighbors but for now it is not needed
                             //initial DB snapshot covers current uses cases for RDK-B but we can update this part if needed in the future
                         }
-                        UpdateType::ApAutoConfigSearch { registrar } => {
-                            if let Some(registrar) = registrar {
-                                node.device_data.registrar = registrar;
+                        UpdateType::ApAutoConfigSearch => {
+                            if let Some(registrar) = device_data.registrar
+                                && node.device_data.registrar != Some(registrar)
+                            {
+                                info!("node {al_mac:?} registrar flag changed to  {registrar}");
+                                node.device_data.registrar = Some(registrar);
                             }
 
                             node.prepare_link_metrics_query_transmission_event_if_needed()
                                 .into_iter()
                                 .collect()
-                        }
-                        UpdateType::ApAutoConfigResponse { registrar } => {
-                            if let Some(registrar) = registrar {
-                                node.device_data.registrar = registrar;
-                            }
-                            vec![]
                         }
                     };
                 }
@@ -1042,7 +1039,7 @@ impl TopologyDatabase {
                             debug!(al_mac = ?al_mac, "Inserted node from query");
                             vec![TransmissionEvent::SendTopologyResponse(al_mac)]
                         }
-                        UpdateType::ApAutoConfigSearch { .. } => {
+                        UpdateType::ApAutoConfigSearch => {
                             let node = nodes.entry(al_mac).insert_entry(new_node).into_mut();
                             node_was_created = true;
                             debug!(al_mac = ?al_mac, "Inserted node from ApAutoConfigSearch");
@@ -1144,12 +1141,20 @@ impl TopologyDatabase {
     pub async fn handle_ap_auto_config_response(
         &self,
         source: MacAddr,
+        supported_role: SupportedRole,
         supported_freq_band: SupportedFreqBand,
     ) {
         let mut nodes = self.nodes.write().await;
         let Some(node) = Self::find_node_by_port_mut(nodes.values_mut(), source) else {
             return debug!(%source, "handle_ap_auto_config_response — node not found");
         };
+
+        let registrar = supported_role.role == SupportedRole::TYPE_REGISTRAR;
+        if node.device_data.registrar != Some(registrar) {
+            let al_mac = node.metadata.al_mac;
+            info!("node {al_mac:?} registrar flag changed to {registrar}");
+            node.device_data.registrar = Some(registrar);
+        }
 
         node.device_data.supported_freq_band = Some(supported_freq_band);
     }


### PR DESCRIPTION
Adds registrar tracking to the topology database.

- adds `registrar: bool` to topology node device data
- updates a remote topology node when role information is received:
  - search with `SearchedRole(Registrar)` -> remote node is `registrar: false`
  - response with `SupportedRole(Registrar)` -> remote node is `registrar: true`

```
2026-06-21T06:37:22.457131Z INFO al_sap{task=4}: ieee1905::al_sap: ServiceType EasyMeshController - Might be Registrar
2026-06-21T06:37:53.629086Z DEBUG handle_cmdu{task=100 mac=02:01:00:a3:7b:d6}:auto_config_search: ieee1905::cmdu_handler: Handling ApAutoConfigSearch CMDU source=02:01:00:a3:7b:d6 msg_id=1 interface="eth0_virt_peer"
2026-06-21T06:37:53.629878Z TRACE handle_cmdu{task=100 mac=02:01:00:a3:7b:d6}:sdu_from_cmdu: ieee1905::cmdu_handler: Processing TLV index=1 tlv_type=SearchedRole length=1 raw_data=Some([0])
2026-06-21T06:37:53.630257Z TRACE handle_cmdu{task=100 mac=02:01:00:a3:7b:d6}:sdu_from_cmdu: ieee1905::cmdu_handler: Node: Ieee1905Node { metadata: Ieee1905NodeInfo { al_mac: 02:01:00:a3:7b:d6, ... }, device_data: Ieee1905DeviceData { al_mac: 02:01:00:a3:7b:d6, ..., registrar: false, ... } }

2026-06-21T06:37:52.538087Z INFO al_sap{task=7}: ieee1905::al_sap: ServiceType EasyMeshAgent - Might be Enrollee
2026-06-21T06:37:53.645171Z DEBUG handle_cmdu{task=96 mac=02:01:00:a3:7b:c6}:auto_config_response: ieee1905::cmdu_handler: Handling ApAutoConfigResponse CMDU source=02:01:00:a3:7b:c6 msg_id=1 interface="eth1_virt_peer"
2026-06-21T06:37:53.645592Z TRACE handle_cmdu{task=96 mac=02:01:00:a3:7b:c6}:sdu_from_cmdu: ieee1905::cmdu_handler: Processing TLV index=0 tlv_type=SupportedRole length=1 raw_data=Some([0])
2026-06-21T06:37:53.646126Z TRACE handle_cmdu{task=96 mac=02:01:00:a3:7b:c6}:sdu_from_cmdu: ieee1905::cmdu_handler: Node: Ieee1905Node { metadata: Ieee1905NodeInfo { al_mac: 02:01:00:a3:7b:c6, ... }, device_data: Ieee1905DeviceData { al_mac: 02:01:00:a3:7b:c6, ..., registrar: true, ... } }
```